### PR TITLE
Support `carton sdk versions`

### DIFF
--- a/Sources/carton/Commands/Versions.swift
+++ b/Sources/carton/Commands/Versions.swift
@@ -13,10 +13,24 @@
 // limitations under the License.
 
 import ArgumentParser
+import TSCBasic
 
-struct SDK: ParsableCommand {
+struct Versions: ParsableCommand {
   static var configuration = CommandConfiguration(
-    abstract: "Manage installed Swift toolchains and SDKs.",
-    subcommands: [Install.self, Versions.self]
+    abstract: "Lists all installed toolchains/SDKs"
   )
+  
+  func run() throws {
+    guard let terminal = TerminalController(stream: stdoutStream)
+    else { fatalError("failed to create an instance of `TerminalController`") }
+    
+    let versions = try localFileSystem.fetchAllSwiftVersions()
+    if (versions.count > 0) {
+      versions.forEach { version in
+        terminal.write("\(version)\n", inColor: .green)
+      }
+    } else {
+      terminal.write("No sdks installed\n")
+    }
+  }
 }

--- a/Sources/carton/Toolchain/ToolchainManagement.swift
+++ b/Sources/carton/Toolchain/ToolchainManagement.swift
@@ -61,6 +61,14 @@ enum ToolchainError: Error, CustomStringConvertible {
 }
 
 extension FileSystem {
+  private var swiftenvVersionsPath: AbsolutePath {
+    return homeDirectory.appending(components: ".swiftenv", "versions")
+  }
+  
+  private var cartonSDKPath: AbsolutePath {
+    return homeDirectory.appending(components: ".carton", "sdk")
+  }
+  
   private func inferSwiftVersion(
     from versionSpec: String? = nil,
     _ terminal: TerminalController
@@ -119,11 +127,11 @@ extension FileSystem {
       return swiftPath.pathString
     }
 
-    if let path = try checkAndLog(homeDirectory.appending(components: ".swiftenv", "versions")) {
+    if let path = try checkAndLog(swiftenvVersionsPath) {
       return path
     }
 
-    let sdkPath = homeDirectory.appending(components: ".carton", "sdk")
+    let sdkPath = cartonSDKPath
     if let path = try checkAndLog(sdkPath) {
       return path
     }
@@ -281,5 +289,9 @@ extension FileSystem {
     else { fatalError("failed to decode UTF8 output of the `swift build` invocation") }
 
     return AbsolutePath(binPath)
+  }
+  
+  func fetchAllSwiftVersions() throws -> [String] {
+    try getDirectoryContents(cartonSDKPath) + getDirectoryContents(swiftenvVersionsPath)
   }
 }


### PR DESCRIPTION
Move previous description to #15 .

This PR implements `carton sdk versions` to list all installed sdks.