### PR TITLE
Bump OpenCombine version to 0.10.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.1"),
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.2.0")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.1.3")),
-    .package(url: "https://github.com/broadwaylamb/OpenCombine.git", .upToNextMinor(from: "0.9.0")),
+    .package(url: "https://github.com/OpenCombine/OpenCombine.git", .upToNextMinor(from: "0.10.0")),
     .package(url: "https://github.com/vapor/vapor.git", .upToNextMinor(from: "4.5.0")),
   ],
   targets: [


### PR DESCRIPTION
The new version contains important bug fixes that prevent memory leaks.