### PR TITLE
Use `from` instead of `upToNextMinor` for OpenCombine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,9 @@ let package = Package(
     .package(url: "https://github.com/vapor/vapor.git", .upToNextMinor(from: "4.5.0")),
   ],
   targets: [
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+    // Targets are the basic building blocks of a package. A target can define a module
+    // or a test suite. Targets can depend on other targets in this package, and on
+    // products in packages which this package depends on.
     .target(
       name: "carton",
       dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,11 +9,11 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.1"),
     .package(
-      url: "https://github.com/apple/swift-argument-parser", 
+      url: "https://github.com/apple/swift-argument-parser",
       .upToNextMinor(from: "0.2.0")
     ),
     .package(
-      url: "https://github.com/apple/swift-tools-support-core.git", 
+      url: "https://github.com/apple/swift-tools-support-core.git",
       .upToNextMinor(from: "0.1.3")
     ),
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,14 @@ let package = Package(
   platforms: [.macOS(.v10_15)],
   dependencies: [
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.1"),
-    .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.2.0")),
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.1.3")),
+    .package(
+      url: "https://github.com/apple/swift-argument-parser", 
+      .upToNextMinor(from: "0.2.0")
+    ),
+    .package(
+      url: "https://github.com/apple/swift-tools-support-core.git", 
+      .upToNextMinor(from: "0.1.3")
+    ),
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.0"),
     .package(url: "https://github.com/vapor/vapor.git", .upToNextMinor(from: "4.5.0")),
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.1"),
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.2.0")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.1.3")),
-    .package(url: "https://github.com/OpenCombine/OpenCombine.git", .upToNextMinor(from: "0.10.0")),
+    .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.0"),
     .package(url: "https://github.com/vapor/vapor.git", .upToNextMinor(from: "4.5.0")),
   ],
   targets: [


### PR DESCRIPTION
This comes after I was reminded that we're using an old version in https://github.com/swiftwasm/carton/pull/33.