### PR TITLE
Use Combine instead of OpenCombine where possible

### DIFF
--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,13 +1,7 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
-
-let openCombineProduct: Target.Dependency = .product(
-  name: "OpenCombine",
-  package: "OpenCombine",
-  condition: .when(platforms: [.linux])
-)
 
 let package = Package(
   name: "carton",
@@ -37,7 +31,7 @@ let package = Package(
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         .product(name: "Vapor", package: "vapor"),
         "CartonHelpers",
-        openCombineProduct,
+        "OpenCombine",
         "SwiftToolchain",
       ]
     ),
@@ -47,7 +41,7 @@ let package = Package(
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         "CartonHelpers",
-        openCombineProduct,
+        "OpenCombine",
       ]
     ),
     .target(
@@ -55,7 +49,7 @@ let package = Package(
       dependencies: [
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        openCombineProduct,
+        "OpenCombine",
       ]
     ),
     // This target is used only for release automation tasks and

--- a/Sources/CartonHelpers/ProcessRunner.swift
+++ b/Sources/CartonHelpers/ProcessRunner.swift
@@ -14,7 +14,11 @@
 
 import Dispatch
 import Foundation
+#if canImport(Combine)
+import Combine
+#else
 import OpenCombine
+#endif
 import TSCBasic
 
 struct ProcessRunnerError: Error, CustomStringConvertible {

--- a/Sources/SwiftToolchain/ProgressAnimation.swift
+++ b/Sources/SwiftToolchain/ProgressAnimation.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(Combine)
+import Combine
+#else
 import OpenCombine
+#endif
 import TSCBasic
 import TSCUtility
 

--- a/Sources/SwiftToolchain/ToolchainManagement.swift
+++ b/Sources/SwiftToolchain/ToolchainManagement.swift
@@ -15,7 +15,11 @@
 import AsyncHTTPClient
 import CartonHelpers
 import Foundation
+#if canImport(Combine)
+import Combine
+#else
 import OpenCombine
+#endif
 import TSCBasic
 import TSCUtility
 

--- a/Sources/carton/Combine/Watcher.swift
+++ b/Sources/carton/Combine/Watcher.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(Combine)
+import Combine
+#else
 import OpenCombine
+#endif
 import TSCBasic
 import TSCUtility
 

--- a/Sources/carton/Commands/Dev.swift
+++ b/Sources/carton/Commands/Dev.swift
@@ -14,7 +14,11 @@
 
 import ArgumentParser
 import Foundation
+#if canImport(Combine)
+import Combine
+#else
 import OpenCombine
+#endif
 import SwiftToolchain
 import TSCBasic
 

--- a/Sources/carton/Commands/Test.swift
+++ b/Sources/carton/Commands/Test.swift
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 import ArgumentParser
+#if canImport(Combine)
+import Combine
+#else
 import OpenCombine
+#endif
 import TSCBasic
 
 private let dependency = Dependency(

--- a/Sources/carton/Server/Server.swift
+++ b/Sources/carton/Server/Server.swift
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 import CartonHelpers
+#if canImport(Combine)
+import Combine
+#else
 import OpenCombine
+#endif
 import TSCBasic
 import Vapor
 


### PR DESCRIPTION
@ddddxxx with conditional dependencies available in Swift 5.3 I think this resolves the issue that you mentioned in https://github.com/swiftwasm/Tokamak/pull/170. The binary size is only reduced from 23 MB to 21 MB though, I expected a bit more...