### PR TITLE
Add sources to watcher per target

### DIFF
--- a/Sources/SwiftToolchain/Package.swift
+++ b/Sources/SwiftToolchain/Package.swift
@@ -54,4 +54,5 @@ enum TargetType: String, Codable {
 struct Target: Codable {
   let name: String
   let type: TargetType
+  let path: String?
 }

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -107,7 +107,7 @@ public final class Toolchain {
     }
   }
     
-  public func inferSourcePaths() throws -> [String] {
+  public func inferSourcesPaths() throws -> [String] {
     let package = try Package(with: swiftPath, terminal)
     
     let targetPaths = package.targets.compactMap { target -> String? in

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -110,13 +110,13 @@ public final class Toolchain {
   public func inferSourcePaths() throws -> [String] {
     let package = try Package(with: swiftPath, terminal)
     
-    let targetPaths = package.targets.map { target -> String in
+    let targetPaths = package.targets.compactMap { target -> String? in
         guard let path = target.path else {
             switch target.type {
             case .regular:
                 return "Sources/\(target.name)"
             case .test:
-                return "Tests/\(target.name)"
+                return nil
             }
         }
         return path

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -106,6 +106,24 @@ public final class Toolchain {
       return nil
     }
   }
+    
+  public func inferSourcePaths() throws -> [String] {
+    let package = try Package(with: swiftPath, terminal)
+    
+    let targetPaths = package.targets.map { target -> String in
+        guard let path = target.path else {
+            switch target.type {
+            case .regular:
+                return "Sources/\(target.name)"
+            case .test:
+                return "Tests/\(target.name)"
+            }
+        }
+        return path
+    }
+    
+    return targetPaths
+  }
 
   public func buildCurrentProject(
     product: String?,

--- a/Sources/carton/Commands/Dev.swift
+++ b/Sources/carton/Commands/Dev.swift
@@ -58,7 +58,7 @@ struct Dev: ParsableCommand {
       release: release
     )
     
-    let sources = try toolchain.inferSourcePaths().map { source -> [AbsolutePath] in
+    let sources = try toolchain.inferSourcesPaths().map { source -> [AbsolutePath] in
         let relativePath = try RelativePath(validating: source)
         guard let sources = localFileSystem.currentWorkingDirectory?.appending(relativePath)
         else { fatalError("failed to infer the sources directory") }

--- a/TestApp/CustomPathTarget/text.swift
+++ b/TestApp/CustomPathTarget/text.swift
@@ -12,28 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import JavaScriptKit
-import TestLibrary
-import CustomPathTarget
-
-let document = JSObjectRef.global.document.object!
-
-let button = document.createElement!("button").object!
-button.innerText = .string("Crash!")
-let body = document.body.object!
-_ = body.appendChild!(button)
-
-print(text)
-print(customTargetText)
-
-func crash() {
-  let x = [Any]()
-  print(x[1])
-}
-
-let buttonNode = document.getElementsByTagName!("button").object![0].object!
-buttonNode.onclick = .function { _ in
-  print(text)
-  crash()
-  return .undefined
-}
+public let customTargetText = "Hello, custom target!"

--- a/TestApp/Package.swift
+++ b/TestApp/Package.swift
@@ -14,8 +14,9 @@ let package = Package(
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
     // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-    .target(name: "TestApp", dependencies: ["JavaScriptKit", "TestLibrary"]),
+    .target(name: "TestApp", dependencies: ["JavaScriptKit", "TestLibrary", "CustomPathTarget"]),
     .target(name: "TestLibrary"),
+    .target(name: "CustomPathTarget", path: "CustomPathTarget"),
     .testTarget(name: "Tests", dependencies: ["TestLibrary"]),
   ]
 )


### PR DESCRIPTION
Sources are added per target and use a custom path if provided by the package manifest. This should fix #1 !