### PR TITLE
Always pass --enable-test-discovery to swift build

### DIFF
--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -147,6 +147,7 @@ public final class Toolchain {
 
     var builderArguments = [
       swiftPath.pathString, "build", "-c", release ? "release" : "debug", "--product", product,
+      "--enable-test-discovery",
     ]
     let destination = try destination ?? inferDestinationPath().pathString
     builderArguments.append(contentsOf: ["--destination", destination])


### PR DESCRIPTION
Thanks to this the presence of `LinuxMain.swift` file is no longer needed.