### PR TITLE
Add `list` flag and `testCases` argument to `test`

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,6 +39,16 @@
       "command": "swift build && cd TestApp && ../.build/debug/carton test"
     },
     {
+      "label": "build and run test list",
+      "type": "shell",
+      "command": "swift build && cd TestApp && ../.build/debug/carton test -l"
+    },
+    {
+      "label": "build and run test case",
+      "type": "shell",
+      "command": "swift build && cd TestApp && ../.build/debug/carton test Tests.Test/testTrivial"
+    },
+    {
       "type": "npm",
       "script": "build",
       "group": "build",

--- a/Package.resolved
+++ b/Package.resolved
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "55ecc388790d8881a6527833055fcbec3f774404",
-          "version": "4.17.0"
+          "revision": "867ce4ab77de2095b63ab9d3ac27679c882c4839",
+          "version": "4.20.0"
         }
       },
       {


### PR DESCRIPTION
Refines the `carton test` command as a continuation of #42 work.