### PR TITLE
Propagate test build/run failures in the exit code

### DIFF
--- a/Sources/CartonHelpers/ProcessRunner.swift
+++ b/Sources/CartonHelpers/ProcessRunner.swift
@@ -21,6 +21,17 @@ import OpenCombine
 #endif
 import TSCBasic
 
+extension Subscribers.Completion {
+  var result: Result<(), Failure> {
+    switch self {
+    case let .failure(error):
+      return .failure(error)
+    case .finished:
+      return .success(())
+    }
+  }
+}
+
 struct ProcessRunnerError: Error, CustomStringConvertible {
   let description: String
 }
@@ -105,7 +116,7 @@ public final class ProcessRunner {
     try await { completion in
       subscription = publisher
         .sink(
-          receiveCompletion: { _ in completion(Result<(), Never>.success(())) },
+          receiveCompletion: { completion($0.result) },
           receiveValue: { _ in }
         )
     }

--- a/Sources/carton/Helpers/Expectation.swift
+++ b/Sources/carton/Helpers/Expectation.swift
@@ -18,6 +18,9 @@ public struct ExpectationError: Error, CustomStringConvertible {
   public let description: String
 }
 
+/** Implements throwing equality assertions, as compared to standard assertions that trap
+ in debug mode.
+ */
 struct Equality<T: Equatable, C> {
   let description: (_ x: T, _ y: T, _ context: C) -> String
 


### PR DESCRIPTION
Resolves #56.

Also, a brief doc comment is added to the `Equality` assertions helper type.