### PR TITLE
Fix watcher crashing in package subdirectories

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,6 +34,11 @@
       "command": "swift build && cd TestApp && ../.build/debug/carton dev --product TestApp"
     },
     {
+      "label": "build and run dev in subdirectory",
+      "type": "shell",
+      "command": "swift build && cd TestApp/Sources/TestApp && ../../../.build/debug/carton dev --product TestApp"
+    },
+    {
       "label": "build and run test",
       "type": "shell",
       "command": "swift build && cd TestApp && ../.build/debug/carton test"

--- a/Sources/CartonHelpers/ProcessRunner.swift
+++ b/Sources/CartonHelpers/ProcessRunner.swift
@@ -59,7 +59,11 @@ public final class ProcessRunner {
         }, receiveCompletion: {
           switch $0 {
           case .finished:
-            terminal.write("\nProcess completed successfully\n", inColor: .green, bold: false)
+            terminal.write(
+              "\n`\(AbsolutePath(arguments[0]).basename)` process finished successfully\n",
+              inColor: .green,
+              bold: false
+            )
           case let .failure(error):
             let errorString = String(describing: error)
             if errorString.isEmpty {

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -126,9 +126,6 @@ public final class Toolchain {
       throw ToolchainError.missingPackage
     }
 
-    // FIXME: this won't work on Windows
-    let root = AbsolutePath("/")
-
     repeat {
       guard !fileSystem.isFile(cwd.appending(component: "Package.swift")) else {
         return cwd
@@ -136,7 +133,7 @@ public final class Toolchain {
 
       // `parentDirectory` just returns `self` if it's `root`
       cwd = cwd.parentDirectory
-    } while cwd != root
+    } while !cwd.isRoot
 
     throw ToolchainError.missingPackage
   }

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -44,7 +44,10 @@ enum ToolchainError: Error, CustomStringConvertible {
     case .failedToBuildTestBundle:
       return "Failed to build the test bundle"
     case .missingPackage:
-      return "No package found"
+      return """
+      The `Package.swift` manifest file could not be found. Please navigate to a directory that \
+      contains `Package.swift` and restart.
+      """
     }
   }
 }
@@ -118,8 +121,30 @@ public final class Toolchain {
     }
   }
 
+  private func inferManifestDirectory() throws -> AbsolutePath {
+    guard package != nil, var cwd = fileSystem.currentWorkingDirectory else {
+      throw ToolchainError.missingPackage
+    }
+
+    // FIXME: this won't work on Windows
+    let root = AbsolutePath("/")
+
+    repeat {
+      guard !fileSystem.isFile(cwd.appending(component: "Package.swift")) else {
+        return cwd
+      }
+
+      // `parentDirectory` just returns `self` if it's `root`
+      cwd = cwd.parentDirectory
+    } while cwd != root
+
+    throw ToolchainError.missingPackage
+  }
+
   public func inferSourcesPaths() throws -> [AbsolutePath] {
-    let package = try Package(with: swiftPath, terminal)
+    guard let package = package else {
+      throw ToolchainError.missingPackage
+    }
 
     let targetPaths = package.targets.compactMap { target -> String? in
       guard let path = target.path else {
@@ -133,8 +158,10 @@ public final class Toolchain {
       return path
     }
 
+    let manifestDirectory = try inferManifestDirectory()
+
     return try targetPaths.compactMap {
-      try fileSystem.currentWorkingDirectory?.appending(RelativePath(validating: $0))
+      try manifestDirectory.appending(RelativePath(validating: $0))
     }
   }
 

--- a/Sources/carton/Combine/Watcher.swift
+++ b/Sources/carton/Combine/Watcher.swift
@@ -28,6 +28,8 @@ final class Watcher {
   init(_ paths: [AbsolutePath]) throws {
     publisher = subject.eraseToAnyPublisher()
 
+    guard !paths.isEmpty else { return }
+
     fsWatch = FSWatch(paths: paths, latency: 0.1) { [weak self] in
       self?.subject.send($0)
     }

--- a/Sources/carton/Helpers/FileSystem.swift
+++ b/Sources/carton/Helpers/FileSystem.swift
@@ -16,18 +16,18 @@ import Foundation
 import TSCBasic
 
 extension FileSystem {
-  func traverseRecursively(_ root: AbsolutePath) throws -> [AbsolutePath] {
-    guard exists(root, followSymlink: true) else {
+  func traverseRecursively(_ traversalRoot: AbsolutePath) throws -> [AbsolutePath] {
+    guard exists(traversalRoot, followSymlink: true) else {
       return []
     }
 
-    var result = [root]
+    var result = [traversalRoot]
 
-    guard isDirectory(root) else {
+    guard isDirectory(traversalRoot) else {
       return result
     }
 
-    var pathsToTraverse = [root]
+    var pathsToTraverse = [traversalRoot]
     while let currentDirectory = pathsToTraverse.popLast() {
       let directoryContents = try getDirectoryContents(currentDirectory)
         .map(currentDirectory.appending)

--- a/Sources/carton/Helpers/FileSystem.swift
+++ b/Sources/carton/Helpers/FileSystem.swift
@@ -27,7 +27,7 @@ extension FileSystem {
       return result
     }
 
-    var pathsToTraverse = [traversalRoot]
+    var pathsToTraverse = result
     while let currentDirectory = pathsToTraverse.popLast() {
       let directoryContents = try getDirectoryContents(currentDirectory)
         .map(currentDirectory.appending)

--- a/Sources/carton/Helpers/FileSystem.swift
+++ b/Sources/carton/Helpers/FileSystem.swift
@@ -17,8 +17,11 @@ import TSCBasic
 
 extension FileSystem {
   func traverseRecursively(_ root: AbsolutePath) throws -> [AbsolutePath] {
-    precondition(isDirectory(root), "Path \(root) is expected to be a directory")
     var result = [root]
+
+    guard isDirectory(root) else {
+      return result
+    }
 
     var pathsToTraverse = [root]
     while let currentDirectory = pathsToTraverse.popLast() {

--- a/Sources/carton/Helpers/FileSystem.swift
+++ b/Sources/carton/Helpers/FileSystem.swift
@@ -17,7 +17,7 @@ import TSCBasic
 
 extension FileSystem {
   func traverseRecursively(_ root: AbsolutePath) throws -> [AbsolutePath] {
-    precondition(isDirectory(root))
+    precondition(isDirectory(root), "Path \(root) is expected to be a directory")
     var result = [root]
 
     var pathsToTraverse = [root]

--- a/Sources/carton/Helpers/FileSystem.swift
+++ b/Sources/carton/Helpers/FileSystem.swift
@@ -17,6 +17,10 @@ import TSCBasic
 
 extension FileSystem {
   func traverseRecursively(_ root: AbsolutePath) throws -> [AbsolutePath] {
+    guard exists(root, followSymlink: true) else {
+      return []
+    }
+
     var result = [root]
 
     guard isDirectory(root) else {


### PR DESCRIPTION
Currently, when `carton dev` is launched in any subdirectory of the package not containing `Package.swift` it crashes. It's caused by `traverseRecursively` precondition failing when a non-directory (or non-existent) path is passed to it. I think `traverseRecursively` can handle non-existing paths well by returning an empty array, and the path itself when it's a file and not a directory. Thus the precondition check is not needed at all.

Non-existent paths were created due to a wrong assumption that the root package directory is always the current directory. This is now fixed by adding a new `inferManifestDirectory` function, which correctly calculates absolute paths of source directories before passing them to the watcher.

Additionally the watcher code in the `TSCBasic` code has its own precondition for non-empty path arrays passed to it. To avoid triggering it and staying extra-safe, we check for an empty watcher paths array and avoid watching anything at all.