### PR TITLE
Add verbose/concise logging levels

### DIFF
--- a/Sources/CartonHelpers/TerminalController.swift
+++ b/Sources/CartonHelpers/TerminalController.swift
@@ -14,9 +14,24 @@
 
 import TSCBasic
 
+private extension String {
+  static var home = "\u{001B}[H"
+  static var clearScreen = "\u{001B}[2J"
+  static var clear = "\u{001B}[J"
+}
+
 public extension TerminalController {
   func logLookup<T: CustomStringConvertible>(_ description: String, _ target: T) {
     write(description)
     write("\(target)\n", inColor: .cyan, bold: true)
+  }
+
+  func clearWindow() {
+    write(.clearScreen)
+  }
+
+  func homeAndClear() {
+    write(.home)
+    write(.clear)
   }
 }

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -209,6 +209,7 @@ public final class Toolchain {
     let builderArguments = try [
       swiftPath.pathString, "build", "-c", isRelease ? "release" : "debug", "--build-tests",
       "--destination", inferDestinationPath().pathString,
+      "-Xswiftc", "-color-diagnostics",
     ]
 
     try ProcessRunner(builderArguments, terminal).waitUntilFinished()

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -176,6 +176,7 @@ public final class Toolchain {
     let builderArguments = try [
       swiftPath.pathString, "build", "-c", isRelease ? "release" : "debug", "--product", product,
       "--enable-test-discovery", "--destination", destination ?? inferDestinationPath().pathString,
+      "-Xswiftc", "-color-diagnostics",
     ]
 
     try ProcessRunner(builderArguments, terminal).waitUntilFinished()

--- a/Sources/carton/Commands/Dev.swift
+++ b/Sources/carton/Commands/Dev.swift
@@ -37,6 +37,9 @@ struct Dev: ParsableCommand {
   @Flag(help: "When specified, build in the release mode.")
   var release = false
 
+  @Flag(name: .shortAndLong, help: "Don't clear terminal window after files change.")
+  var verbose = false
+
   static let configuration = CommandConfiguration(
     abstract: "Watch the current directory, host the app, rebuild on change."
   )
@@ -57,6 +60,10 @@ struct Dev: ParsableCommand {
 
     let paths = try toolchain.inferSourcesPaths()
 
+    if !verbose {
+      terminal.clearWindow()
+      terminal.homeAndClear()
+    }
     terminal.write("\nWatching these directories for changes:\n", inColor: .green)
     paths.forEach { terminal.logLookup("", $0) }
     terminal.write("\n")
@@ -67,6 +74,7 @@ struct Dev: ParsableCommand {
       builderArguments: arguments,
       pathsToWatch: sources,
       mainWasmPath: mainWasmPath.pathString,
+      verbose: verbose,
       terminal
     ).run()
   }

--- a/Sources/carton/Server/Server.swift
+++ b/Sources/carton/Server/Server.swift
@@ -43,11 +43,12 @@ final class Server {
     builderArguments: [String],
     pathsToWatch: [AbsolutePath],
     mainWasmPath: String,
+    verbose: Bool,
     _ terminal: TerminalController
   ) throws {
     watcher = try Watcher(pathsToWatch)
 
-    var env = Environment(name: "development", arguments: ["vapor"])
+    var env = Environment(name: verbose ? "development" : "production", arguments: ["vapor"])
     try LoggingSystem.bootstrap(from: &env)
     app = Application(env)
     app.configure(
@@ -62,6 +63,9 @@ final class Server {
 
     watcher.publisher
       .flatMap(maxPublishers: .max(1)) { changes -> AnyPublisher<String, Never> in
+        if !verbose {
+          terminal.homeAndClear()
+        }
         terminal.write("\nThese paths have changed, rebuilding...\n", inColor: .yellow)
         for change in changes.map(\.pathString) {
           terminal.write("- \(change)\n", inColor: .cyan)

--- a/Sources/carton/Server/Server.swift
+++ b/Sources/carton/Server/Server.swift
@@ -76,6 +76,7 @@ final class Server {
             guard case .finished = $0 else { return }
 
             terminal.write("\nBuild completed successfully\n", inColor: .green, bold: false)
+            terminal.logLookup("The app is currently hosted at ", "http://127.0.0.1:8080/")
             self?.connections.forEach { $0.send("reload") }
           })
           .catch { _ in Empty().eraseToAnyPublisher() }


### PR DESCRIPTION
This adds a `--verbose/-v` flag to `carton dev`.

When enabled, logging acts the same as before this PR.

Otherwise, the screen is cleared before starting, and after every rebuild. This keeps the most recent diagnostics visible, while keeping the terminal relatively clean. It also switches the Vapor `Environment` to `"production"` to only show logs >= notices.

`-Xswiftc -color-diagnostics` is also passed to the Swift compiler for both levels.

Let me know if any of this is behavior isn't desired.