### PR TITLE
Fix crash caused by use of `try!` while installing invalid version

### DIFF
--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -26,6 +26,7 @@ enum ToolchainError: Error, CustomStringConvertible {
   case failedToBuild(product: String)
   case failedToBuildTestBundle
   case missingPackage
+  case invalidVersion(version: String)
 
   var description: String {
     switch self {
@@ -48,6 +49,8 @@ enum ToolchainError: Error, CustomStringConvertible {
       The `Package.swift` manifest file could not be found. Please navigate to a directory that \
       contains `Package.swift` and restart.
       """
+    case let .invalidVersion(version):
+      return "Invalid version \(version)"
     }
   }
 }

--- a/Sources/SwiftToolchain/ToolchainManagement.swift
+++ b/Sources/SwiftToolchain/ToolchainManagement.swift
@@ -128,8 +128,7 @@ extension FileSystem {
       client.execute(request: request).map { response -> Release? in
         guard let body = response.body else { return nil }
 
-        // swiftlint:disable:next force_try
-        return try! decoder.decode(Release.self, from: body)
+        return try? decoder.decode(Release.self, from: body)
       }.whenComplete($0)
     }) else { return nil }
 
@@ -231,7 +230,8 @@ extension FileSystem {
     } else if let inferredURL = try inferDownloadURL(from: swiftVersion, client, terminal) {
       downloadURL = inferredURL
     } else {
-      fatalError("Failed to infer download URL for version \(swiftVersion)")
+      terminal.write("The Swift version \(swiftVersion) not found\n", inColor: .red)
+      throw ToolchainError.invalidVersion(version: swiftVersion)
     }
 
     terminal.write(

--- a/Sources/SwiftToolchain/ToolchainManagement.swift
+++ b/Sources/SwiftToolchain/ToolchainManagement.swift
@@ -230,7 +230,7 @@ extension FileSystem {
     } else if let inferredURL = try inferDownloadURL(from: swiftVersion, client, terminal) {
       downloadURL = inferredURL
     } else {
-      terminal.write("The Swift version \(swiftVersion) not found\n", inColor: .red)
+      terminal.write("The Swift version \(swiftVersion) was not found\n", inColor: .red)
       throw ToolchainError.invalidVersion(version: swiftVersion)
     }
 


### PR DESCRIPTION
Fix #72.

If you are installing an invalid version, It'll now throw an `InvalidVersion` error and the output will be more friendly.