### PR TITLE
Avoid using 3rd-party action for the Linux build

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,15 +12,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Build
-        run: swift build
+      - name: Build on macOS 10.15 with Swift 5.2
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_11.6.app/Contents/Developer
+          swift build
 
   linux_build:
     runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
-      - name: Test on Ubuntu with Swift 5.2
-        uses: Didstopia/SwiftAction@v1.0.2
-        with:
-          swift-action: build -Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none
+      - name: Build on Ubuntu 20.04 with Swift 5.2
+        run: |
+          swift build


### PR DESCRIPTION
This should unblock https://github.com/swiftwasm/carton/pull/74 as we currently can't install sqlite headers as a part of the build process with that action.

Standard GitHub Actions Ubuntu 20.04 VMs already supply Swift 5.2, so there's no strong reason to keep using 3rd-party actions for Linux builds.