### PR TITLE
Update `tokamak` template for the new TokamakUI org

### DIFF
--- a/Sources/carton/Model/Template.swift
+++ b/Sources/carton/Model/Template.swift
@@ -170,7 +170,7 @@ extension Templates {
         dependencies: [
           .init(
             name: "Tokamak",
-            url: "https://github.com/swiftwasm/Tokamak",
+            url: "https://github.com/TokamakUI/Tokamak",
             version: .from("0.3.0")
           ),
         ],


### PR DESCRIPTION
As the Tokamak project has been moved to a separate [TokamakUI organization](https://github.com/TokamakUI), the template has been updated accordingly.