### PR TITLE
Disable release builds with `carton bundle`

### DIFF
--- a/Sources/carton/Commands/Bundle.swift
+++ b/Sources/carton/Commands/Bundle.swift
@@ -51,7 +51,8 @@ struct Bundle: ParsableCommand {
     let (_, mainWasmPath) = try toolchain.buildCurrentProject(
       product: product,
       destination: nil,
-      isRelease: !debug
+      // FIXME: change to `!debug` after https://github.com/swiftwasm/swift/issues/1679 is resolved
+      isRelease: false
     )
     try terminal.logLookup(
       "Right after building the main binary size is ",


### PR DESCRIPTION
Due to https://github.com/swiftwasm/swift/issues/1679, any project depending on Tokamak can't be built with `carton bundle`. Working around that by disabling release builds for now, and will re-enable them in the future version, when a new toolchain snapshot is available to fix this.