### PR TITLE
Bump default toolchain version, fix release builds

### DIFF
--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-08-15-a"
+public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-09-08-a"

--- a/Sources/carton/Commands/Bundle.swift
+++ b/Sources/carton/Commands/Bundle.swift
@@ -107,6 +107,6 @@ struct Bundle: ParsableCommand {
       ))
     )
 
-    terminal.write("\nBundle generation finished successfully", inColor: .green, bold: true)
+    terminal.write("\nBundle generation finished successfully\n", inColor: .green, bold: true)
   }
 }


### PR DESCRIPTION
The latest 5.3 toolchain snapshot fixes release builds of Tokamak. 

We no longer need `carton bundle` to produce debug builds by default, so it closes #103 as outdated.

Formatting of a `carton bundle` message is fixed as it didn't have a required trailing newline.