### PR TITLE
Automatically open a browser window when Dev Server starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ new [Tokamak](https://tokamak.dev/) project, while `carton init --template basic
 currently).
 
 The `carton dev` command builds your project with the SwiftWasm toolchain and starts an HTTP server
-that hosts your WebAssembly executable and a corresponding JavaScript entrypoint that loads it. Open
-[http://127.0.0.1:8080/](http://127.0.0.1:8080/) in your browser to see the app running. You can
+that hosts your WebAssembly executable and a corresponding JavaScript entrypoint that loads it. The app, reachable at [http://127.0.0.1:8080/](http://127.0.0.1:8080/), will automatically open in your default web browser. You can
 edit the app source code in your favorite editor and save it, `carton` will immediately rebuild the
 app and reload all browser tabs that have the app open. You can also pass a `--verbose` flag to
 keep the build process output available, otherwise stale output is cleaned up from your terminal

--- a/Sources/carton/Commands/Dev.swift
+++ b/Sources/carton/Commands/Dev.swift
@@ -47,6 +47,9 @@ struct Dev: ParsableCommand {
   @Option(name: .shortAndLong, help: "Set the HTTP port the app will run on.")
   var port = 8080
 
+  @Flag(name: .long, help: "Skip automatically opening app in system browser.")
+  var skipAutoOpen = false
+
   static let configuration = CommandConfiguration(
     abstract: "Watch the current directory, host the app, rebuild on change."
   )
@@ -84,6 +87,7 @@ struct Dev: ParsableCommand {
       // swiftlint:disable:next force_try
       package: try! toolchain.package.get(),
       verbose: verbose,
+      skipAutoOpen: skipAutoOpen,
       terminal,
       port: port
     ).run()

--- a/Sources/carton/Server/Server.swift
+++ b/Sources/carton/Server/Server.swift
@@ -122,11 +122,11 @@ extension Server: LifecycleHandler {
   @discardableResult
   private func openInSystemBrowser(url: String) -> Bool {
     #if os(macOS)
-      let openCommand = "open"
+    let openCommand = "open"
     #elseif os(Linux)
-      let openCommand = "xdg-open"
+    let openCommand = "xdg-open"
     #else
-      return false
+    return false
     #endif
     let process = Process(
       arguments: [openCommand, url],
@@ -134,9 +134,11 @@ extension Server: LifecycleHandler {
       verbose: false,
       startNewProcessGroup: true
     )
-    guard let _ = try? process.launch() else {
+    do {
+      try process.launch()
+      return true
+    } catch {
       return false
     }
-    return true
   }
 }

--- a/Sources/carton/Server/Server.swift
+++ b/Sources/carton/Server/Server.swift
@@ -40,6 +40,7 @@ final class Server {
   private var builder: ProcessRunner?
   private let app: Application
   private let localURL: String
+  private let skipAutoOpen: Bool
 
   init(
     builderArguments: [String],
@@ -48,6 +49,7 @@ final class Server {
     customIndexContent: String?,
     package: SwiftToolchain.Package,
     verbose: Bool,
+    skipAutoOpen: Bool,
     _ terminal: InteractiveWriter,
     port: Int
   ) throws {
@@ -55,6 +57,7 @@ final class Server {
 
     var env = Environment(name: verbose ? "development" : "production", arguments: ["vapor"])
     localURL = "http://127.0.0.1:\(port)/"
+    self.skipAutoOpen = skipAutoOpen
 
     try LoggingSystem.bootstrap(from: &env)
     app = Application(env)
@@ -110,6 +113,7 @@ final class Server {
 
 extension Server: LifecycleHandler {
   public func didBoot(_ application: Application) throws {
+    guard !skipAutoOpen else { return }
     openInSystemBrowser(url: localURL)
   }
 


### PR DESCRIPTION
Resolves #92.
While there [a lot](https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/openBrowser.js) [more](https://github.com/sindresorhus/open) options possible to cram here I think this is a decent start. Perhaps an opportunity for a cross-platform Swift launcher µ framework?  