### PR TITLE
Pretty print diagnostics

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -47,6 +47,15 @@
         }
       },
       {
+        "package": "Splash",
+        "repositoryURL": "https://github.com/JohnSundell/Splash",
+        "state": {
+          "branch": null,
+          "revision": "f25dd8c9f16be1f81a152f6861d7216c3c9302da",
+          "version": "0.14.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/JohnSundell/Splash",
         "state": {
           "branch": null,
-          "revision": "f25dd8c9f16be1f81a152f6861d7216c3c9302da",
-          "version": "0.14.0"
+          "revision": "ca9a1b7bff35381fe5ae9fe2ec9333cc5f2a586c",
+          "version": "0.13.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -48,11 +48,11 @@
       },
       {
         "package": "Splash",
-        "repositoryURL": "https://github.com/JohnSundell/Splash",
+        "repositoryURL": "https://github.com/JohnSundell/Splash.git",
         "state": {
           "branch": null,
-          "revision": "ca9a1b7bff35381fe5ae9fe2ec9333cc5f2a586c",
-          "version": "0.13.0"
+          "revision": "f25dd8c9f16be1f81a152f6861d7216c3c9302da",
+          "version": "0.14.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.0"),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.29.3"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "1.1.0"),
-    .package(url: "https://github.com/JohnSundell/Splash", .exact("0.13.0")),
+    .package(url: "https://github.com/JohnSundell/Splash.git", from: "0.14.0"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.0"),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.29.3"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "1.1.0"),
-    .package(url: "https://github.com/JohnSundell/Splash", from: "0.14.0"),
+    .package(url: "https://github.com/JohnSundell/Splash", .exact("0.13.0")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.0"),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.29.3"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "1.1.0"),
+    .package(url: "https://github.com/JohnSundell/Splash", from: "0.14.0"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module
@@ -58,6 +59,7 @@ let package = Package(
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         openCombineProduct,
+        "Splash",
       ]
     ),
     // This target is used only for release automation tasks and

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -19,6 +19,7 @@ let package = Package(
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.0"),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.29.3"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "1.1.0"),
+    .package(url: "https://github.com/JohnSundell/Splash.git", from: "0.14.0"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module
@@ -52,6 +53,7 @@ let package = Package(
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         "OpenCombine",
+        "Splash",
       ]
     ),
     // This target is used only for release automation tasks and

--- a/Sources/CartonHelpers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/DiagnosticsParser.swift
@@ -1,0 +1,207 @@
+// Copyright 2020 Carton contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import TSCBasic
+import Splash
+
+fileprivate extension StringProtocol {
+  func matches(regex: NSRegularExpression) -> String.SubSequence? {
+    let str = String(self)
+    let range = NSRange(location: 0, length: utf16.count)
+    guard let match = regex.firstMatch(in: str, options: [], range: range),
+          let matchRange = Range(match.range, in: String(self)) else {
+      return nil
+    }
+    return str[matchRange.upperBound..<str.endIndex]
+  }
+}
+
+fileprivate extension String.StringInterpolation {
+  mutating func appendInterpolation<T>(_ value: T, color: String...) {
+    appendInterpolation("\(color.map { "\u{001B}\($0)" }.joined())\(value)\u{001B}[0m")
+  }
+}
+
+fileprivate extension TokenType {
+  var color: String {
+    switch self {
+    case .keyword: return "[35;1m"
+    case .comment: return "[90m"
+    case .call, .dotAccess, .property, .type: return "[94m"
+    case .number, .preprocessing: return "[33m"
+    case .string: return "[91;1m"
+    default: return "[0m"
+    }
+  }
+}
+
+fileprivate struct TerminalOutputFormat: OutputFormat {
+  func makeBuilder() -> TerminalOutputBuilder {
+    .init()
+  }
+  
+  struct TerminalOutputBuilder: OutputBuilder {
+    var output: String = ""
+    
+    mutating func addToken(_ token: String, ofType type: TokenType) {
+      output.append("\(token, color: type.color)")
+    }
+    
+    mutating func addPlainText(_ text: String) {
+      output.append(text)
+    }
+    
+    mutating func addWhitespace(_ whitespace: String) {
+      output.append(whitespace)
+    }
+    
+    mutating func build() -> String {
+      output
+    }
+  }
+}
+
+/// Parses and re-formats diagnostics output by the Swift compiler.
+///
+/// The compiler output often repeats iteself, and the diagnostics can sometimes be difficult to read.
+/// This reformats them to a more readable output.
+struct DiagnosticsParser {
+  enum Regex {
+    /// The output has moved to a new file
+    static let enterFile = try! NSRegularExpression(pattern: #"\[\d+\/\d+\] Compiling \w+ "#)
+    /// A message is beginning with the line # following the `:`
+    static let line = try! NSRegularExpression(pattern: #"(\/\w+)+\.\w+:"#)
+  }
+  
+  struct CustomDiagnostic {
+    let kind: Kind
+    let line: String.SubSequence
+    let char: String.SubSequence
+    let code: String
+    let message: String.SubSequence
+    
+    enum Kind: String {
+      case error, warning, note
+      var color: String {
+        switch self {
+        case .error: return "[41;1m"
+        case .warning: return "[43;1m"
+        case .note: return "[47;1m"
+        }
+      }
+    }
+  }
+  
+  fileprivate static let highlighter = SyntaxHighlighter(format: TerminalOutputFormat())
+  
+  func parse(_ output: String, _ terminal: InteractiveWriter) {
+    let lines = output.split(separator: "\n")
+    var lineIdx = 0
+    
+    var diagnostics = [String.SubSequence:[CustomDiagnostic]]()
+    
+    var currFile: String.SubSequence?
+    var fileMessages = [CustomDiagnostic]()
+    
+    while lineIdx < lines.count {
+      let line = lines[lineIdx]
+      if let file = line.matches(regex: Regex.enterFile) {
+        if let currFile = currFile {
+          diagnostics[currFile] = fileMessages
+        }
+        currFile = file
+        fileMessages = []
+      } else if currFile != nil {
+        if let message = line.matches(regex: Regex.line) {
+          let components = message.split(separator: ":")
+          if components.count > 3 {
+            lineIdx += 1
+            fileMessages.append(
+              .init(
+                kind: CustomDiagnostic.Kind(rawValue: String(components[2].trimmingCharacters(in: .whitespaces))) ?? .note,
+                line: components[0],
+                char: components[1],
+                code: String(lines[lineIdx]),
+                message: components[3]
+              )
+            )
+          }
+        }
+      } else {
+        terminal.write(String(line) + "\n", inColor: .cyan)
+      }
+      lineIdx += 1
+    }
+    
+    for (file, messages) in diagnostics.sorted(by: { $0.key < $1.key }) {
+      guard messages.count > 0 else { continue }
+      terminal.write("\(" \(file) ", color: "[1m", "[7m")\n\n")
+      // Group messages that occur on sequential lines to provie a more readable output
+      var groupedMessages = [[CustomDiagnostic]]()
+      for message in messages {
+        if let lastLineStr = groupedMessages.last?.last?.line,
+           let lastLine = Int(lastLineStr),
+           let line = Int(message.line),
+           lastLine == line - 1 || lastLine == line {
+          groupedMessages[groupedMessages.count - 1].append(message)
+        } else {
+          groupedMessages.append([message])
+        }
+      }
+      for messages in groupedMessages {
+        // Output the diagnostic message
+        for message in messages {
+          terminal.write("  \(" \(message.kind.rawValue.uppercased()) ", color: message.kind.color) \(message.message)\n")
+        }
+        let maxLine = messages.map(\.line.count).max() ?? 0
+        for (offset, message) in messages.enumerated() {
+          func flush() {
+            // Get all diagnostics for a particular line.
+            let allChars = messages.filter { $0.line == message.line }.map(\.char)
+            // Output the code for this line, syntax highlighted
+            terminal.write("  \("\(message.line.padding(toLength: maxLine, withPad: " ", startingAt: 0)) | ", color: "[36m")\(Self.highlighter.highlight(message.code))\n")
+            terminal.write("  " + "".padding(toLength: maxLine, withPad: " ", startingAt: 0) + " | ", inColor: .cyan)
+            
+            // Aggregate the indicators (^ point to the error) onto a single line
+            var charIndicators = String(repeating: " ", count: Int(message.char)!) + "^"
+            if allChars.count > 0 {
+              for char in allChars.dropFirst() {
+                let idx = Int(char)!
+                if idx >= charIndicators.count {
+                  charIndicators.append(String(repeating: " ", count: idx - charIndicators.count) + "^")
+                } else {
+                  var arr = Array(charIndicators)
+                  arr[idx] = "^"
+                  charIndicators = String(arr)
+                }
+              }
+            }
+            terminal.write("\(charIndicators)\n", inColor: .red, bold: true)
+          }
+          if offset > 0 {
+            // Make sure we don't log the same line twice
+            if messages[offset - 1].line != message.line {
+              flush()
+            }
+          } else {
+            flush()
+          }
+        }
+        terminal.write("\n")
+      }
+      terminal.write("\n")
+    }
+  }
+}

--- a/Sources/CartonHelpers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/DiagnosticsParser.swift
@@ -230,9 +230,11 @@ struct DiagnosticsParser {
     // Get all diagnostics for a particular line.
     let allChars = messages.filter { $0.line == message.line }.map(\.char)
     // Output the code for this line, syntax highlighted
+    let paddedLine = message.line.padding(toLength: maxLine, withPad: " ", startingAt: 0)
+    let highlightedCode = Self.highlighter.highlight(message.code)
     terminal
       .write(
-        "  \("\(message.line.padding(toLength: maxLine, withPad: " ", startingAt: 0)) | ", color: "[36m")\(Self.highlighter.highlight(message.code))\n"
+        "  \("\(paddedLine) | ", color: "[36m")\(highlightedCode)\n"
       ) // 36: cyan
     terminal.write(
       "  " + "".padding(toLength: maxLine, withPad: " ", startingAt: 0) + " | ",

--- a/Sources/CartonHelpers/InteractiveWriter.swift
+++ b/Sources/CartonHelpers/InteractiveWriter.swift
@@ -53,11 +53,11 @@ public final class InteractiveWriter {
       stream.flush()
     }
   }
-  
+
   public func saveCursor() {
     term?.write("\u{001B}[s")
   }
-  
+
   public func revertCursorAndClear() {
     term?.write("\u{001B}[u\u{001B}[2J\u{001B}H")
   }

--- a/Sources/CartonHelpers/InteractiveWriter.swift
+++ b/Sources/CartonHelpers/InteractiveWriter.swift
@@ -53,4 +53,12 @@ public final class InteractiveWriter {
       stream.flush()
     }
   }
+  
+  public func saveCursor() {
+    term?.write("\u{001B}[s")
+  }
+  
+  public func revertCursorAndClear() {
+    term?.write("\u{001B}[u\u{001B}[2J\u{001B}H")
+  }
 }

--- a/Sources/CartonHelpers/ProcessRunner.swift
+++ b/Sources/CartonHelpers/ProcessRunner.swift
@@ -41,6 +41,7 @@ public final class ProcessRunner {
 
   private var subscription: AnyCancellable?
 
+  // swiftlint:disable:next function_body_length
   public init(
     _ arguments: [String],
     clearOutputLines: Bool = true,
@@ -54,6 +55,8 @@ public final class ProcessRunner {
         receiveOutput: {
           if clearOutputLines {
             // Aggregate this for formatting later
+            terminal.clearLine()
+            terminal.write(loadingMessage, inColor: .yellow)
             tmpOutput += $0
           } else {
             terminal.write($0)
@@ -78,7 +81,10 @@ public final class ProcessRunner {
               )
               DiagnosticsParser().parse(tmpOutput, terminal)
             } else {
-              terminal.write("\nProcess failed and produced following output: \n", inColor: .red)
+              terminal.write(
+                "\nProcess failed and produced following output: \n",
+                inColor: .red
+              )
               print(error)
             }
           }
@@ -117,7 +123,8 @@ public final class ProcessRunner {
         subject.send(completion: .failure(error))
       default:
         let errorDescription = String(data: Data(stderrBuffer), encoding: .utf8) ?? ""
-        return subject.send(completion: .failure(ProcessRunnerError(description: errorDescription)))
+        return subject
+          .send(completion: .failure(ProcessRunnerError(description: errorDescription)))
       }
     }
   }

--- a/Sources/CartonHelpers/TerminalController.swift
+++ b/Sources/CartonHelpers/TerminalController.swift
@@ -16,7 +16,7 @@ import TSCBasic
 
 private extension String {
   static var home = "\u{001B}[H"
-  static var clearScreen = "\u{001B}[2J"
+  static var clearScreen = "\u{001B}[2J\u{001B}[H\u{001B}[3J"
   static var clear = "\u{001B}[J"
 }
 

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -223,10 +223,10 @@ public final class Toolchain {
     let builderArguments = try [
       swiftPath.pathString, "build", "-c", isRelease ? "release" : "debug", "--product", product,
       "--enable-test-discovery", "--destination", destination ?? inferDestinationPath().pathString,
-//      "-Xswiftc", "-color-diagnostics",
     ]
 
-    try ProcessRunner(builderArguments, loadingMessage: "Compiling...", terminal).waitUntilFinished()
+    try ProcessRunner(builderArguments, loadingMessage: "Compiling...", terminal)
+      .waitUntilFinished()
 
     guard localFileSystem.exists(mainWasmPath) else {
       terminal.write(

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -223,10 +223,10 @@ public final class Toolchain {
     let builderArguments = try [
       swiftPath.pathString, "build", "-c", isRelease ? "release" : "debug", "--product", product,
       "--enable-test-discovery", "--destination", destination ?? inferDestinationPath().pathString,
-      "-Xswiftc", "-color-diagnostics",
+//      "-Xswiftc", "-color-diagnostics",
     ]
 
-    try ProcessRunner(builderArguments, terminal).waitUntilFinished()
+    try ProcessRunner(builderArguments, loadingMessage: "Compiling...", terminal).waitUntilFinished()
 
     guard localFileSystem.exists(mainWasmPath) else {
       terminal.write(

--- a/Sources/carton/Commands/Dev.swift
+++ b/Sources/carton/Commands/Dev.swift
@@ -74,7 +74,7 @@ struct Dev: ParsableCommand {
 
     let paths = try toolchain.inferSourcesPaths()
 
-    if !verbose {    
+    if !verbose {
       terminal.revertCursorAndClear()
     }
     terminal.write("\nWatching these directories for changes:\n", inColor: .green)

--- a/Sources/carton/Commands/Dev.swift
+++ b/Sources/carton/Commands/Dev.swift
@@ -60,7 +60,7 @@ struct Dev: ParsableCommand {
     try Self.dependency.check(on: localFileSystem, terminal)
 
     let toolchain = try Toolchain(localFileSystem, terminal)
-    
+
     if !verbose {
       terminal.clearWindow()
       terminal.saveCursor()

--- a/Sources/carton/Commands/Dev.swift
+++ b/Sources/carton/Commands/Dev.swift
@@ -60,6 +60,11 @@ struct Dev: ParsableCommand {
     try Self.dependency.check(on: localFileSystem, terminal)
 
     let toolchain = try Toolchain(localFileSystem, terminal)
+    
+    if !verbose {
+      terminal.clearWindow()
+      terminal.saveCursor()
+    }
 
     let (arguments, mainWasmPath) = try toolchain.buildCurrentProject(
       product: product,
@@ -69,9 +74,8 @@ struct Dev: ParsableCommand {
 
     let paths = try toolchain.inferSourcesPaths()
 
-    if !verbose {
-      terminal.clearWindow()
-      terminal.homeAndClear()
+    if !verbose {    
+      terminal.revertCursorAndClear()
     }
     terminal.write("\nWatching these directories for changes:\n", inColor: .green)
     paths.forEach { terminal.logLookup("", $0) }

--- a/Sources/carton/Server/Server.swift
+++ b/Sources/carton/Server/Server.swift
@@ -79,7 +79,7 @@ final class Server {
     watcher.publisher
       .flatMap(maxPublishers: .max(1)) { changes -> AnyPublisher<String, Never> in
         if !verbose {
-          terminal.homeAndClear()
+          terminal.clearWindow()
         }
         terminal.write("\nThese paths have changed, rebuilding...\n", inColor: .yellow)
         for change in changes.map(\.pathString) {


### PR DESCRIPTION
The output from the Swift compiler can be pretty verbose. This adds better formatting and syntax highlighting to the compiler's output (modeled after the error messages of React).

<img width="828" alt="Screen Shot 2020-10-06 at 3 56 56 PM" src="https://user-images.githubusercontent.com/13581484/95254716-4f5c6c00-07ee-11eb-9bff-af55c53bc295.png">

I also modified the screen-clearing to reset the scrollback so you can easily find the first error without scrolling past it.