### PR TITLE
Remove sudo usage from `install_ubuntu_deps.sh`

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build on Ubuntu 18.04 with Swift 5.3
         run: |
           swift build
-          ./install_ubuntu_deps.sh
+          sudo ./install_ubuntu_deps.sh
           curl https://get.wasmer.io -sSfL | sh
           source /home/runner/.wasmer/wasmer.sh
           cd TestApp && ../.build/debug/carton test

--- a/install_ubuntu_deps.sh
+++ b/install_ubuntu_deps.sh
@@ -4,8 +4,8 @@ set -ex
 
 curl -L -v -o wabt.tar.gz https://github.com/WebAssembly/wabt/releases/download/1.0.19/wabt-1.0.19-ubuntu.tar.gz
 tar xzvf wabt.tar.gz
-sudo cp wabt-1.0.19/bin/* /usr/local/bin
+cp wabt-1.0.19/bin/* /usr/local/bin
 
 curl -L -v -o binaryen.tar.gz https://github.com/WebAssembly/binaryen/releases/download/version_97/binaryen-version_97-x86_64-linux.tar.gz
 tar xzvf binaryen.tar.gz
-sudo cp binaryen-version_97/bin/* /usr/local/bin
+cp binaryen-version_97/bin/* /usr/local/bin


### PR DESCRIPTION
`sudo` is not always available in Docker containers, so we should assume users will run the script itself with `sudo` when needed.