### PR TITLE
Add support for signed `.pkg` archives on macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu AS build
 
 ADD https://github.com/swiftwasm/swift/releases/download/\
-swift-wasm-5.3-SNAPSHOT-2020-10-15-a/\
-swift-wasm-5.3-SNAPSHOT-2020-10-15-a-ubuntu20.04-x86_64.tar.gz \
+swift-wasm-5.3-SNAPSHOT-2020-10-21-a/\
+swift-wasm-5.3-SNAPSHOT-2020-10-21-a-ubuntu20.04_x86_64.tar.gz \
   /swift-wasm-5.3-SNAPSHOT.tar.gz
 RUN mkdir -p /home/builder/.carton/sdk && cd /home/builder/.carton/sdk && \
   tar xzf /swift-wasm-5.3-SNAPSHOT.tar.gz && \
-  mv swift-wasm-5.3-SNAPSHOT-2020-10-15-a wasm-5.3-SNAPSHOT-2020-10-15-a && \
-  cd wasm-5.3-SNAPSHOT-2020-10-15-a/usr/bin && rm *-test swift-refactor sourcekit-lsp
+  mv swift-wasm-5.3-SNAPSHOT-2020-10-21-a wasm-5.3-SNAPSHOT-2020-10-21-a && \
+  cd wasm-5.3-SNAPSHOT-2020-10-21-a/usr/bin && rm *-test swift-refactor sourcekit-lsp
 
 # Container image that runs your code
 FROM ubuntu:20.04
@@ -41,7 +41,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 
 COPY --from=build /home/builder/.carton /root/.carton
 
-RUN ln -s /root/.carton/sdk/wasm-5.3-SNAPSHOT-2020-10-15-a/usr/bin/swift /usr/bin/swift
+RUN ln -s /root/.carton/sdk/wasm-5.3-SNAPSHOT-2020-10-21-a/usr/bin/swift /usr/bin/swift
 
 COPY . carton/
 

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-10-15-a"
+public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-10-20-a"

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-10-20-a"
+public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-10-21-a"

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -31,6 +31,7 @@ enum ToolchainError: Error, CustomStringConvertible {
   case invalidVersion(version: String)
   case invalidResponse(url: String, status: UInt)
   case unsupportedOperatingSystem
+  case noInstallationDirectory(path: String)
 
   var description: String {
     switch self {
@@ -59,6 +60,10 @@ enum ToolchainError: Error, CustomStringConvertible {
       return "Response from \(url) had invalid status \(status) or didn't contain body"
     case .unsupportedOperatingSystem:
       return "This version of the operating system is not supported"
+    case let .noInstallationDirectory(path):
+      return """
+      Failed to infer toolchain installation directory. Please make sure that \(path) exists.
+      """
     }
   }
 }

--- a/Sources/SwiftToolchain/ToolchainInstallation.swift
+++ b/Sources/SwiftToolchain/ToolchainInstallation.swift
@@ -1,0 +1,138 @@
+// Copyright 2020 Carton contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import AsyncHTTPClient
+import CartonHelpers
+import Foundation
+#if canImport(Combine)
+import Combine
+#else
+import OpenCombine
+#endif
+import TSCBasic
+import TSCUtility
+
+private let expectedArchiveSize = 891_856_371
+
+extension FileSystem {
+  func installSDK(
+    version: String,
+    from url: Foundation.URL,
+    to sdkPath: AbsolutePath,
+    _ client: HTTPClient,
+    _ terminal: InteractiveWriter
+  ) throws -> AbsolutePath {
+    if !exists(sdkPath, followSymlink: true) {
+      try createDirectory(sdkPath, recursive: true)
+    }
+
+    guard isDirectory(sdkPath) else {
+      throw ToolchainError.directoryDoesNotExist(sdkPath)
+    }
+
+    let ext = url.pathExtension
+
+    let archivePath = sdkPath.appending(component: "\(version).\(ext)")
+    let (delegate, subject) = try downloadDelegate(path: archivePath.pathString, terminal)
+
+    var subscriptions = [AnyCancellable]()
+    let request = try HTTPClient.Request.get(url: url)
+
+    _ = try await { (completion: @escaping (Result<(), Error>) -> ()) in
+      client.execute(request: request, delegate: delegate).futureResult.whenComplete { _ in
+        subject.send(completion: .finished)
+      }
+
+      subject
+        .removeDuplicates {
+          // only report values that differ in more than 1%
+          $1.step - $0.step < ($0.total / 100)
+        }
+        .handle(
+          with: PercentProgressAnimation(stream: stdoutStream, header: "Downloading the archive")
+        )
+        .sink(
+          receiveCompletion: {
+            switch $0 {
+            case .finished:
+              terminal.write("Download completed successfully\n", inColor: .green)
+              completion(.success(()))
+            case let .failure(error):
+              terminal.write("Download failed\n", inColor: .red)
+              completion(.failure(error))
+            }
+          },
+          receiveValue: { _ in }
+        )
+        .store(in: &subscriptions)
+    }
+
+    let installationPath: AbsolutePath
+
+    let arguments: [String]
+    if ext == "pkg" {
+      guard let libraryPath = NSSearchPathForDirectoriesInDomains(
+        .libraryDirectory, .userDomainMask, true
+      ).first else {
+        throw ToolchainError.noInstallationDirectory(path: "~/Library")
+      }
+      installationPath = AbsolutePath(libraryPath).appending(
+        components: "Developer", "Toolchains", "swift-\(version).xctoolchain"
+      )
+      arguments = [
+        "installer", "-target", "CurrentUserHomeDirectory", "-pkg", archivePath.pathString,
+      ]
+    } else {
+      installationPath = sdkPath.appending(component: version)
+      try createDirectory(installationPath, recursive: true)
+
+      arguments = [
+        "tar", "xzf", archivePath.pathString, "--strip-components=1",
+        "--directory", installationPath.pathString,
+      ]
+    }
+    terminal.logLookup("Unpacking the archive: ", arguments.joined(separator: " "))
+    _ = try processDataOutput(arguments)
+
+    try removeFileTree(archivePath)
+
+    return installationPath
+  }
+
+  private func downloadDelegate(
+    path: String,
+    _ terminal: InteractiveWriter
+  ) throws -> (FileDownloadDelegate, PassthroughSubject<Progress, Error>) {
+    let subject = PassthroughSubject<Progress, Error>()
+    return try (FileDownloadDelegate(
+      path: path,
+      reportHead: {
+        guard $0.status == .ok,
+          let totalBytes = $0.headers.first(name: "Content-Length").flatMap(Int.init)
+        else {
+          subject.send(completion: .failure(ToolchainError.invalidResponseCode($0.status.code)))
+          return
+        }
+        terminal.write("Archive size is \(totalBytes / 1_000_000) MB\n", inColor: .yellow)
+      },
+      reportProgress: {
+        subject.send(.init(
+          step: $1,
+          total: $0 ?? expectedArchiveSize,
+          text: "saving to \(path)"
+        ))
+      }
+    ), subject)
+  }
+}


### PR DESCRIPTION
`carton` can't install toolchains from `.pkg` archives at the moment, and the latest toolchain snapshots are distributed exclusively as signed `.pkg` for macOS.

Parts of `ToolchainManagement.swift` related to toolchain installation were moved to `ToolchainInstallation.swift`.