### PR TITLE
Avoid repeated `loadingMessage` in `ProcessRunner`

### DIFF
--- a/Sources/CartonHelpers/ProcessRunner.swift
+++ b/Sources/CartonHelpers/ProcessRunner.swift
@@ -52,11 +52,13 @@ public final class ProcessRunner {
     var tmpOutput = ""
     publisher = subject
       .handleEvents(
+        receiveSubscription: { _ in
+          terminal.clearLine()
+          terminal.write(loadingMessage, inColor: .yellow)
+        },
         receiveOutput: {
           if clearOutputLines {
             // Aggregate this for formatting later
-            terminal.clearLine()
-            terminal.write(loadingMessage, inColor: .yellow)
             tmpOutput += $0
           } else {
             terminal.write($0)


### PR DESCRIPTION
Without this patch `ProcessRunner` output pollutes non-interactive terminals such as GitHub Actions logs, where `loadingMessage` value is printed multiple times in a row for every compiled file.