### PR TITLE
Bump JavaScriptKit to 0.8, stop checking revision

### DIFF
--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -17,8 +17,7 @@ import Foundation
 import TSCBasic
 import TSCUtility
 
-private let compatibleJSKitRevision = "6e84a70"
-public let compatibleJSKitVersion = Version(0, 7, 2)
+public let compatibleJSKitVersion = Version(0, 8, 0)
 
 enum ToolchainError: Error, CustomStringConvertible {
   case directoryDoesNotExist(AbsolutePath)
@@ -68,8 +67,7 @@ extension Package.Dependency.Requirement {
     if let upperBound = range?.first?.upperBound, let version = Version(string: upperBound) {
       return version >= compatibleJSKitVersion
     }
-    return revision == [compatibleJSKitRevision] ||
-      exact?.compactMap { Version(string: $0) } == [compatibleJSKitVersion]
+    return exact?.compactMap { Version(string: $0) } == [compatibleJSKitVersion]
   }
 
   var version: String {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2120,9 +2120,9 @@
       "dev": true
     },
     "javascript-kit-swift": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/javascript-kit-swift/-/javascript-kit-swift-0.7.2.tgz",
-      "integrity": "sha512-ggFmNp+rQxNr6atsZUp89+N6eD+c/iUyjZGKUlc6TcAbqhDJFZoCCKGArJzHEcfPZOLI8Ih96iiOKgXhM+8LAw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/javascript-kit-swift/-/javascript-kit-swift-0.8.0.tgz",
+      "integrity": "sha512-27t4Jky9Wlj467nlBZGjvLPJnv5lmd+Es7M6Do7aRJE0ArYi8BQDX7RyadqWCglE/a2wOkQ0ErjHcupR24lrRQ==",
       "dev": true
     },
     "json-parse-better-errors": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@wasmer/wasi": "^0.12.0",
     "@wasmer/wasmfs": "^0.12.0",
-    "javascript-kit-swift": "^0.7.2",
+    "javascript-kit-swift": "^0.8.0",
     "reconnecting-websocket": "^4.4.0",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12"


### PR DESCRIPTION
Other than a simple bump, we shouldn't check for the revision anymore. Now the recommended way to specify this dependency is only with a semantic version constraint.