### PR TITLE
Fix error message output

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,8 +18,8 @@ jobs:
           swift test -c release
           swift build -c release
           brew bundle
-          cd TestApp && ../.build/debug/carton test
-          ../.build/debug/carton bundle
+          cd TestApp && ../.build/release/carton test
+          ../.build/release/carton bundle
         # the token is required to get around GitHub API limits when downloading the toolchain
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,8 +35,8 @@ jobs:
           swift test -c release
           swift build -c release
           brew bundle
-          cd TestApp && ../.build/debug/carton test
-          ../.build/debug/carton bundle
+          cd TestApp && ../.build/release/carton test
+          ../.build/release/carton bundle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,8 +51,8 @@ jobs:
           swift test -c release
           swift build -c release
           brew bundle
-          cd TestApp && ../.build/debug/carton test
-          ../.build/debug/carton bundle
+          cd TestApp && ../.build/release/carton test
+          ../.build/release/carton bundle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -67,8 +67,8 @@ jobs:
           swift test -c release
           swift build -c release
           brew bundle
-          cd TestApp && ../.build/debug/carton test
-          ../.build/debug/carton bundle
+          cd TestApp && ../.build/release/carton test
+          ../.build/release/carton bundle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -85,8 +85,8 @@ jobs:
           sudo ./install_ubuntu_deps.sh
           curl https://get.wasmer.io -sSfL | sh
           source /home/runner/.wasmer/wasmer.sh
-          cd TestApp && ../.build/debug/carton test
-          ../.build/debug/carton bundle
+          cd TestApp && ../.build/release/carton test
+          ../.build/release/carton bundle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -103,8 +103,8 @@ jobs:
           sudo ./install_ubuntu_deps.sh
           curl https://get.wasmer.io -sSfL | sh
           source /home/runner/.wasmer/wasmer.sh
-          cd TestApp && ../.build/debug/carton test
-          ../.build/debug/carton bundle
+          cd TestApp && ../.build/release/carton test
+          ../.build/release/carton bundle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build on macOS 10.15 with Swift 5.2
         run: |
           sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
-          swift test -c release
+          swift test -c release --enable-test-discovery
           swift build -c release
           brew bundle
           cd TestApp && ../.build/release/carton test
@@ -32,7 +32,7 @@ jobs:
       - name: Build on macOS 11.0 with Swift 5.2
         run: |
           sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
-          swift test -c release
+          swift test -c release --enable-test-discovery
           swift build -c release
           brew bundle
           cd TestApp && ../.build/release/carton test
@@ -48,7 +48,7 @@ jobs:
       - name: Build on macOS 10.15 with Swift 5.3
         run: |
           sudo xcode-select --switch /Applications/Xcode_12.app/Contents/Developer
-          swift test -c release
+          swift test -c release --enable-test-discovery
           swift build -c release
           brew bundle
           cd TestApp && ../.build/release/carton test
@@ -64,7 +64,7 @@ jobs:
       - name: Build on macOS 11.0 with Swift 5.3
         run: |
           sudo xcode-select --switch /Applications/Xcode_12.1.app/Contents/Developer
-          swift test -c release
+          swift test -c release --enable-test-discovery
           swift build -c release
           brew bundle
           cd TestApp && ../.build/release/carton test
@@ -80,7 +80,7 @@ jobs:
 
       - name: Build on Ubuntu 18.04 with Swift 5.3
         run: |
-          swift test -c release
+          swift test -c release --enable-test-discovery
           swift build -c release
           sudo ./install_ubuntu_deps.sh
           curl https://get.wasmer.io -sSfL | sh
@@ -98,7 +98,7 @@ jobs:
 
       - name: Build on Ubuntu 20.04 with Swift 5.3
         run: |
-          swift test -c release
+          swift test -c release --enable-test-discovery
           swift build -c release
           sudo ./install_ubuntu_deps.sh
           curl https://get.wasmer.io -sSfL | sh

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Build on macOS 10.15 with Swift 5.2
         run: |
           sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
-          swift build
+          swift test -c release
+          swift build -c release
           brew bundle
           cd TestApp && ../.build/debug/carton test
           ../.build/debug/carton bundle
@@ -31,7 +32,8 @@ jobs:
       - name: Build on macOS 11.0 with Swift 5.2
         run: |
           sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
-          swift build
+          swift test -c release
+          swift build -c release
           brew bundle
           cd TestApp && ../.build/debug/carton test
           ../.build/debug/carton bundle
@@ -46,7 +48,8 @@ jobs:
       - name: Build on macOS 10.15 with Swift 5.3
         run: |
           sudo xcode-select --switch /Applications/Xcode_12.app/Contents/Developer
-          swift build
+          swift test -c release
+          swift build -c release
           brew bundle
           cd TestApp && ../.build/debug/carton test
           ../.build/debug/carton bundle
@@ -61,7 +64,8 @@ jobs:
       - name: Build on macOS 11.0 with Swift 5.3
         run: |
           sudo xcode-select --switch /Applications/Xcode_12.1.app/Contents/Developer
-          swift build
+          swift test -c release
+          swift build -c release
           brew bundle
           cd TestApp && ../.build/debug/carton test
           ../.build/debug/carton bundle
@@ -76,7 +80,8 @@ jobs:
 
       - name: Build on Ubuntu 18.04 with Swift 5.3
         run: |
-          swift build
+          swift test -c release
+          swift build -c release
           sudo ./install_ubuntu_deps.sh
           curl https://get.wasmer.io -sSfL | sh
           source /home/runner/.wasmer/wasmer.sh
@@ -93,7 +98,8 @@ jobs:
 
       - name: Build on Ubuntu 20.04 with Swift 5.3
         run: |
-          swift build
+          swift test -c release
+          swift build -c release
           sudo ./install_ubuntu_deps.sh
           curl https://get.wasmer.io -sSfL | sh
           source /home/runner/.wasmer/wasmer.sh

--- a/Package.swift
+++ b/Package.swift
@@ -80,7 +80,7 @@ let package = Package(
       dependencies: [
         "carton",
         "CartonHelpers",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ]
     ),
   ]

--- a/Package.swift
+++ b/Package.swift
@@ -77,7 +77,11 @@ let package = Package(
     ),
     .testTarget(
       name: "CartonTests",
-      dependencies: ["carton"]
+      dependencies: [
+        "carton",
+        "CartonHelpers",
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
+      ]
     ),
   ]
 )

--- a/Sources/CartonHelpers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/DiagnosticsParser.swift
@@ -105,7 +105,7 @@ struct DiagnosticsParser {
     let line: String.SubSequence
     let char: String.SubSequence
     let code: String
-    let message: String.SubSequence
+    let message: String
 
     enum Kind: String {
       case error, warning, note
@@ -157,7 +157,7 @@ struct DiagnosticsParser {
                 line: components[0],
                 char: components[1],
                 code: String(lines[lineIdx]),
-                message: components[3]
+                message: components.dropFirst(3).joined(separator: ":")
               )
             )
           }

--- a/Sources/CartonHelpers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/DiagnosticsParser.swift
@@ -120,7 +120,7 @@ public struct DiagnosticsParser {
   }
 
   fileprivate static let highlighter = SyntaxHighlighter(format: TerminalOutputFormat())
-  
+
   public init() {}
 
   public func parse(_ output: String, _ terminal: InteractiveWriter) {

--- a/Sources/CartonHelpers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/DiagnosticsParser.swift
@@ -88,7 +88,7 @@ private struct TerminalOutputFormat: OutputFormat {
 /// The compiler output often repeats iteself, and the diagnostics can sometimes be
 /// difficult to read.
 /// This reformats them to a more readable output.
-struct DiagnosticsParser {
+public struct DiagnosticsParser {
   // swiftlint:disable force_try
   enum Regex {
     /// The output has moved to a new file
@@ -120,8 +120,10 @@ struct DiagnosticsParser {
   }
 
   fileprivate static let highlighter = SyntaxHighlighter(format: TerminalOutputFormat())
+  
+  public init() {}
 
-  func parse(_ output: String, _ terminal: InteractiveWriter) {
+  public func parse(_ output: String, _ terminal: InteractiveWriter) {
     let lines = output.split(separator: "\n")
     var lineIdx = 0
 

--- a/Tests/CartonTests/CartonTests.swift
+++ b/Tests/CartonTests/CartonTests.swift
@@ -1,7 +1,21 @@
 import class Foundation.Bundle
 import XCTest
+@testable import CartonHelpers
+import TSCBasic
 
 final class CartonTests: XCTestCase {
+  /// Returns path to the built products directory.
+  var productsDirectory: URL {
+    #if os(macOS)
+    for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+      return bundle.bundleURL.deletingLastPathComponent()
+    }
+    fatalError("couldn't find the products directory")
+    #else
+    return Bundle.main.bundleURL
+    #endif
+  }
+  
   func testExample() throws {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct
@@ -28,20 +42,59 @@ final class CartonTests: XCTestCase {
 
     XCTAssertEqual(output, "Hello, world!\n")
   }
-
-  /// Returns path to the built products directory.
-  var productsDirectory: URL {
-    #if os(macOS)
-    for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-      return bundle.bundleURL.deletingLastPathComponent()
+  
+  final class TestOutputStream: OutputByteStream {
+    var bytes: [UInt8] = []
+    var currentOutput: String {
+      String(bytes: bytes, encoding: .utf8)!
     }
-    fatalError("couldn't find the products directory")
-    #else
-    return Bundle.main.bundleURL
-    #endif
+    var position: Int = 0
+    
+    init() {}
+    
+    func flush() {}
+    
+    func write(_ byte: UInt8) {
+      bytes.append(byte)
+    }
+    
+    func write<C>(_ bytes: C) where C : Collection, C.Element == UInt8 {
+      self.bytes.append(contentsOf: bytes)
+    }
+  }
+  
+  func testDiagnosticsParser() {
+    let testDiagnostics = #"""
+    [1/1] Compiling TokamakCore Font.swift
+    /Users/username/Project/Sources/TokamakCore/Tokens/Font.swift:58:15: error: invalid redeclaration of 'resolve(in:)'
+      public func resolve(in environment: EnvironmentValues) -> _Font {
+                  ^
+    /Users/username/Project/Sources/TokamakCore/Tokens/Font.swift:55:15: note: 'resolve(in:)' previously declared here
+      public func resolve(in environment: EnvironmentValues) -> _Font {
+                  ^
+    """#
+    let expectedOutput = #"""
+    \u{001B}[1m\u{001B}[7m Font.swift \u{001B}[0m /Users/username/Project/Sources/TokamakCore/Tokens/Font.swift:58
+
+      \u{001B}[41;1m\u{001B}[37;1m ERROR \u{001B}[0m  invalid redeclaration of 'resolve(in:)'
+      \u{001B}[36m58 | \u{001B}[0m   \u{001B}[35;1mpublic\u{001B}[0m \u{001B}[35;1mfunc\u{001B}[0m resolve(in environment: \u{001B}[94mEnvironmentValues\u{001B}[0m) -> \u{001B}[94m_Font\u{001B}[0m {
+         |                ^
+
+      \u{001B}[7m\u{001B}[37;1m NOTE \u{001B}[0m  'resolve(in:)' previously declared here
+      \u{001B}[36m55 | \u{001B}[0m   \u{001B}[35;1mpublic\u{001B}[0m \u{001B}[35;1mfunc\u{001B}[0m resolve(in environment: \u{001B}[94mEnvironmentValues\u{001B}[0m) -> \u{001B}[94m_Font\u{001B}[0m {
+         |                ^
+
+
+
+    """#.replacingOccurrences(of: #"\u{001B}"#, with: "\u{001B}")
+    let stream = TestOutputStream()
+    let writer = InteractiveWriter(stream: stream)
+    DiagnosticsParser().parse(testDiagnostics, writer)
+    XCTAssertEqual(stream.currentOutput, expectedOutput)
   }
 
   static var allTests = [
     ("testExample", testExample),
+    ("testDiagnosticsParser", testDiagnosticsParser),
   ]
 }

--- a/Tests/CartonTests/CartonTests.swift
+++ b/Tests/CartonTests/CartonTests.swift
@@ -16,7 +16,7 @@ final class CartonTests: XCTestCase {
     #endif
   }
   
-  func testExample() throws {
+  func testVersion() throws {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct
     // results.
@@ -93,9 +93,4 @@ final class CartonTests: XCTestCase {
     DiagnosticsParser().parse(testDiagnostics, writer)
     XCTAssertEqual(stream.currentOutput, expectedOutput)
   }
-
-  static var allTests = [
-//    ("testExample", testExample),
-    ("testDiagnosticsParser", testDiagnosticsParser),
-  ]
 }

--- a/Tests/CartonTests/CartonTests.swift
+++ b/Tests/CartonTests/CartonTests.swift
@@ -1,7 +1,7 @@
-import class Foundation.Bundle
-import XCTest
 import CartonHelpers
+import class Foundation.Bundle
 import TSCBasic
+import XCTest
 
 final class CartonTests: XCTestCase {
   /// Returns path to the built products directory.
@@ -15,7 +15,7 @@ final class CartonTests: XCTestCase {
     return Bundle.main.bundleURL
     #endif
   }
-  
+
   func testVersion() throws {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct
@@ -40,31 +40,33 @@ final class CartonTests: XCTestCase {
 
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     let output = String(data: data, encoding: .utf8)
-    
+
     XCTAssertEqual(output?.trimmingCharacters(in: .whitespacesAndNewlines), "0.7.1")
   }
-  
+
   final class TestOutputStream: OutputByteStream {
     var bytes: [UInt8] = []
     var currentOutput: String {
       String(bytes: bytes, encoding: .utf8)!
     }
+
     var position: Int = 0
-    
+
     init() {}
-    
+
     func flush() {}
-    
+
     func write(_ byte: UInt8) {
       bytes.append(byte)
     }
-    
-    func write<C>(_ bytes: C) where C : Collection, C.Element == UInt8 {
+
+    func write<C>(_ bytes: C) where C: Collection, C.Element == UInt8 {
       self.bytes.append(contentsOf: bytes)
     }
   }
-  
+
   func testDiagnosticsParser() {
+    // swiftlint:disable line_length
     let testDiagnostics = """
     [1/1] Compiling TokamakCore Font.swift
     /Users/username/Project/Sources/TokamakCore/Tokens/Font.swift:58:15: error: invalid redeclaration of 'resolve(in:)'
@@ -88,6 +90,7 @@ final class CartonTests: XCTestCase {
 
 
     """
+    // swiftlint:enable line_length
     let stream = TestOutputStream()
     let writer = InteractiveWriter(stream: stream)
     DiagnosticsParser().parse(testDiagnostics, writer)

--- a/Tests/CartonTests/CartonTests.swift
+++ b/Tests/CartonTests/CartonTests.swift
@@ -64,7 +64,7 @@ final class CartonTests: XCTestCase {
   }
   
   func testDiagnosticsParser() {
-    let testDiagnostics = #"""
+    let testDiagnostics = """
     [1/1] Compiling TokamakCore Font.swift
     /Users/username/Project/Sources/TokamakCore/Tokens/Font.swift:58:15: error: invalid redeclaration of 'resolve(in:)'
       public func resolve(in environment: EnvironmentValues) -> _Font {
@@ -72,8 +72,8 @@ final class CartonTests: XCTestCase {
     /Users/username/Project/Sources/TokamakCore/Tokens/Font.swift:55:15: note: 'resolve(in:)' previously declared here
       public func resolve(in environment: EnvironmentValues) -> _Font {
                   ^
-    """#
-    let expectedOutput = #"""
+    """
+    let expectedOutput = """
     \u{001B}[1m\u{001B}[7m Font.swift \u{001B}[0m /Users/username/Project/Sources/TokamakCore/Tokens/Font.swift:58
 
       \u{001B}[41;1m\u{001B}[37;1m ERROR \u{001B}[0m  invalid redeclaration of 'resolve(in:)'
@@ -86,7 +86,7 @@ final class CartonTests: XCTestCase {
 
 
 
-    """#.replacingOccurrences(of: #"\u{001B}"#, with: "\u{001B}")
+    """
     let stream = TestOutputStream()
     let writer = InteractiveWriter(stream: stream)
     DiagnosticsParser().parse(testDiagnostics, writer)

--- a/Tests/CartonTests/CartonTests.swift
+++ b/Tests/CartonTests/CartonTests.swift
@@ -1,6 +1,6 @@
 import class Foundation.Bundle
 import XCTest
-@testable import CartonHelpers
+import CartonHelpers
 import TSCBasic
 
 final class CartonTests: XCTestCase {
@@ -34,13 +34,14 @@ final class CartonTests: XCTestCase {
     let pipe = Pipe()
     process.standardOutput = pipe
 
+    process.arguments = ["--version"]
     try process.run()
     process.waitUntilExit()
 
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     let output = String(data: data, encoding: .utf8)
-
-    XCTAssertEqual(output, "Hello, world!\n")
+    
+    XCTAssertEqual(output?.trimmingCharacters(in: .whitespacesAndNewlines), "0.7.1")
   }
   
   final class TestOutputStream: OutputByteStream {
@@ -94,7 +95,7 @@ final class CartonTests: XCTestCase {
   }
 
   static var allTests = [
-    ("testExample", testExample),
+//    ("testExample", testExample),
     ("testDiagnosticsParser", testDiagnosticsParser),
   ]
 }

--- a/Tests/CartonTests/XCTestManifests.swift
+++ b/Tests/CartonTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-  [
-    testCase(CartonTests.allTests),
-  ]
-}
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,1 @@
-import CartonTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += CartonTests.allTests()
-XCTMain(tests)
+fatalError("Use `swift test --enable-test-discovery` to run tests")


### PR DESCRIPTION
Previously, an error message such as:
```
 ERROR   invalid redeclaration of 'resolve(in:)'
  58 |    public func resolve(in environment: EnvironmentValues) -> _Font {
```
would be output:
```
 ERROR   invalid redeclaration of 'resolve(in
  58 |    public func resolve(in environment: EnvironmentValues) -> _Font {
```
if the message had a colon.