### PR TITLE
Use Xcode 12.2 on macOS Big Sur

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build on macOS 11.0 with Swift 5.3
         run: |
-          sudo xcode-select --switch /Applications/Xcode_12.1.app/Contents/Developer
+          sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
           swift test -c release --enable-test-discovery
           swift build -c release
           brew bundle


### PR DESCRIPTION
For some reason GHA Big Sur hosts no longer have Xcode 12.1 installed as evidenced by CI failures in #141 and #144. We can use Xcode 12.2 instead.