### PR TITLE
Fix handling of binaries with `.wasm` extension

### DIFF
--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-10-26-a"
+public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-10-29-c"

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -216,7 +216,7 @@ public final class Toolchain {
     }
 
     let binPath = try inferBinPath(isRelease: isRelease)
-    let mainWasmPath = binPath.appending(component: product)
+    let mainWasmPath = binPath.appending(component: "\(product).wasm")
     terminal.logLookup("- development binary to serve: ", mainWasmPath.pathString)
 
     terminal.write("\nBuilding the project before spinning up a server...\n", inColor: .yellow)


### PR DESCRIPTION
Latest toolchains produce binaries with the `.wasm` extension which `carton` can't handle yet.