### PR TITLE
Build only test product and its deps for testing

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,6 +39,11 @@
       "command": "swift build -c release && cd TestApp && ../.build/release/carton dev"
     },
     {
+      "label": "build release and run dev verbose",
+      "type": "shell",
+      "command": "swift build -c release && cd TestApp && ../.build/release/carton dev -v"
+    },
+    {
       "label": "build and run dev on 9090 port",
       "type": "shell",
       "command": "swift build && cd TestApp && ../.build/debug/carton dev --port 9090"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu AS build
 
 ADD https://github.com/swiftwasm/swift/releases/download/\
-swift-wasm-5.3-SNAPSHOT-2020-10-21-a/\
-swift-wasm-5.3-SNAPSHOT-2020-10-21-a-ubuntu20.04_x86_64.tar.gz \
+swift-wasm-5.3-SNAPSHOT-2020-10-29-c/\
+swift-wasm-5.3-SNAPSHOT-2020-10-29-c-ubuntu20.04_x86_64.tar.gz \
   /swift-wasm-5.3-SNAPSHOT.tar.gz
 RUN mkdir -p /home/builder/.carton/sdk && cd /home/builder/.carton/sdk && \
   tar xzf /swift-wasm-5.3-SNAPSHOT.tar.gz && \
-  mv swift-wasm-5.3-SNAPSHOT-2020-10-21-a wasm-5.3-SNAPSHOT-2020-10-21-a && \
-  cd wasm-5.3-SNAPSHOT-2020-10-21-a/usr/bin && rm *-test swift-refactor sourcekit-lsp
+  mv swift-wasm-5.3-SNAPSHOT-2020-10-29-c wasm-5.3-SNAPSHOT-2020-10-29-c && \
+  cd wasm-5.3-SNAPSHOT-2020-10-29-c/usr/bin && rm *-test swift-refactor sourcekit-lsp
 
 # Container image that runs your code
 FROM ubuntu:20.04
@@ -41,7 +41,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 
 COPY --from=build /home/builder/.carton /root/.carton
 
-RUN ln -s /root/.carton/sdk/wasm-5.3-SNAPSHOT-2020-10-21-a/usr/bin/swift /usr/bin/swift
+RUN ln -s /root/.carton/sdk/wasm-5.3-SNAPSHOT-2020-10-29-c/usr/bin/swift /usr/bin/swift
 
 COPY . carton/
 

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -244,7 +244,8 @@ public final class Toolchain {
   public func buildTestBundle(isRelease: Bool) throws -> AbsolutePath {
     let package = try self.package.get()
     let binPath = try inferBinPath(isRelease: isRelease)
-    let testBundlePath = binPath.appending(component: "\(package.name)PackageTests.xctest")
+    let testProductName = "\(package.name)PackageTests"
+    let testBundlePath = binPath.appending(component: "\(testProductName).xctest")
     terminal.logLookup("- test bundle to run: ", testBundlePath.pathString)
 
     terminal.write(
@@ -254,8 +255,8 @@ public final class Toolchain {
 
     let builderArguments = [
       swiftPath.pathString, "build", "-c", isRelease ? "release" : "debug",
-      "--product", "\(package.name)PackageTests", "--enable-test-discovery",
-      "--triple", "wasm32-unknown-wasi", "-Xswiftc", "-color-diagnostics",
+      "--product", testProductName, "--enable-test-discovery", "--triple", "wasm32-unknown-wasi",
+      "-Xswiftc", "-color-diagnostics",
     ]
 
     try Builder(

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -253,9 +253,9 @@ public final class Toolchain {
     )
 
     let builderArguments = [
-      swiftPath.pathString, "build", "-c", isRelease ? "release" : "debug", "--build-tests",
-      "--enable-test-discovery", "--triple", "wasm32-unknown-wasi",
-      "-Xswiftc", "-color-diagnostics",
+      swiftPath.pathString, "build", "-c", isRelease ? "release" : "debug",
+      "--product", "\(package.name)PackageTests", "--enable-test-discovery",
+      "--triple", "wasm32-unknown-wasi", "-Xswiftc", "-color-diagnostics",
     ]
 
     try Builder(


### PR DESCRIPTION
Every Swift package with test targets has an implicit test product with `"\(package.name)PackageTests"` name. `swift build --build-tests` builds all products in a given package including the implicit test product. This doesn't work in situations where some of the products can't be compiled for Wasm, even when they are excluded with `condition: .when(platforms: [.macOS, .linux])` from test dependencies. This prevents tests from being built at all in such packages. OpenCombine is the primary victim of this problem.

Fortunately, the implicit test product can be accessed through the `--product` option passed to `swift build`. When using that option, only the test product and its dependencies are built. Products (and therefore their underlying targets) that aren't needed for tests are excluded from such builds. We should explicitly pass `--product` option to `swift build` instead of `--build-tests` in the `carton test` implementation to resolve the issue.

I've also added a new task to `tasks.json` that I previously used for testing `carton dev -v`.

`Dockerfile` has been updated to use the same toolchain as it does in `DefaultToolchain.swift`.