### PR TITLE
Format testing time to two decimal places

### DIFF
--- a/Sources/CartonHelpers/Parsers/TestsParser.swift
+++ b/Sources/CartonHelpers/Parsers/TestsParser.swift
@@ -319,7 +319,7 @@ public struct TestsParser: ProcessOutputParser {
 
     let totalDuration = allTests.compactMap { Double($0.duration) }.reduce(0, +)
     terminal.write("Time:        ")
-    terminal.write("\(totalDuration)s, estimated \(Int(totalDuration.rounded(.up)))s\n")
+    terminal.write("\(String(format: "%.2f", totalDuration))s\n")
 
     if suites.contains(where: { $0.name == "All tests" }) {
       terminal.write("\("Ran all test suites.", color: "[90m")\n") // gray


### PR DESCRIPTION
Currently test report outputs time as something like `0.17200000000000013s, estimated 1s`. This is not very readable, so maybe something like `0.17s` would be better?