### PR TITLE
Fix handling of test products with .wasm extension

### DIFF
--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-10-29-c"
+public let defaultToolchainVersion = "wasm-5.3-SNAPSHOT-2020-11-02-a"

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -245,7 +245,7 @@ public final class Toolchain {
     let package = try self.package.get()
     let binPath = try inferBinPath(isRelease: isRelease)
     let testProductName = "\(package.name)PackageTests"
-    let testBundlePath = binPath.appending(component: "\(testProductName).xctest")
+    let testBundlePath = binPath.appending(component: "\(testProductName).wasm")
     terminal.logLookup("- test bundle to run: ", testBundlePath.pathString)
 
     terminal.write(


### PR DESCRIPTION
After https://github.com/apple/swift-package-manager/pull/3013 was merged and cherry-picked for our 5.3 snapshots (starting with `wasm-5.3-SNAPSHOT-2020-11-02-a`), `carton test` needs to handle the `.wasm` extension in test products.