### PR TITLE
[WIP] Align pretty-printed diagnostic messages with source code that uses horizontal whitespace characters other than space (U+0020)

### DIFF
--- a/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
@@ -228,10 +228,11 @@ public struct DiagnosticsParser: ProcessOutputParser {
     // Output the code for this line, syntax highlighted
     let highlightedCode = Self.highlighter.highlight(message.code)
     terminal.write("  \("\(paddedLine) | ", color: "[36m")\(highlightedCode)\n") // 36: cyan
-    terminal.write("  " + "".padding(toLength: maxLine, withPad: " ", startingAt: 0) + " | ", inColor: .cyan)
     /// A base-10 representation of the number of the row that the diagnosis is for, aligned vertically with all other rows.
     let verticallyAlignedLineNumber = String(message.lineNumber, radix: 10).padding(toLength: minimumSizeForLineNumbering, withPad: " ", startingAt: 0)
+    // Each line of diagnostics output is indented with 2 spaces.
     terminal.write("  \("\(verticallyAlignedLineNumber) | ", color: "[36m")\(highlightedCode)\n") // 36: cyan
+    terminal.write("  \(String(repeating: " ", count: minimumSizeForLineNumbering)) | ", inColor: .cyan)
 
     // Aggregate the indicators (^ point to the error) onto a single line
     var charIndicators = String(repeating: " ", count: Int(message.char)!) + "^"

--- a/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
@@ -158,7 +158,7 @@ public struct DiagnosticsParser: ProcessOutputParser {
       guard messages.count > 0 else { continue }
       terminal.write("\(" \(file) ", color: "[1m", "[7m")") // bold, reversed
       terminal.write(" \(messages.first!.file)\(messages.first!.line)\n\n", inColor: .grey)
-      // Group messages that occur on sequential lines to provie a more readable output
+      // Group messages that occur on sequential lines to provide a more readable output
       var groupedMessages = [[CustomDiagnostic]]()
       for message in messages {
         if let lastLineStr = groupedMessages.last?.last?.line,

--- a/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
@@ -208,14 +208,8 @@ public struct DiagnosticsParser: ProcessOutputParser {
     // Output the code for this line, syntax highlighted
     let paddedLine = message.line.padding(toLength: maxLine, withPad: " ", startingAt: 0)
     let highlightedCode = Self.highlighter.highlight(message.code)
-    terminal
-      .write(
-        "  \("\(paddedLine) | ", color: "[36m")\(highlightedCode)\n"
-      ) // 36: cyan
-    terminal.write(
-      "  " + "".padding(toLength: maxLine, withPad: " ", startingAt: 0) + " | ",
-      inColor: .cyan
-    )
+    terminal.write("  \("\(paddedLine) | ", color: "[36m")\(highlightedCode)\n") // 36: cyan
+    terminal.write("  " + "".padding(toLength: maxLine, withPad: " ", startingAt: 0) + " | ", inColor: .cyan)
 
     // Aggregate the indicators (^ point to the error) onto a single line
     var charIndicators = String(repeating: " ", count: Int(message.char)!) + "^"

--- a/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
@@ -125,11 +125,8 @@ public struct DiagnosticsParser: ProcessOutputParser {
               .replacingOccurrences(of: ":", with: "") == String(currFile)
             else { continue }
             fileMessages.append(
-              .init(
-                kind: CustomDiagnostic
-                  .Kind(rawValue: String(components[2]
-                      .trimmingCharacters(in: .whitespaces))) ??
-                  .note,
+              CustomDiagnostic(
+                kind: CustomDiagnostic.Kind(rawValue: String(components[2].trimmingCharacters(in: .whitespaces))) ?? .note,
                 file: file,
                 // FIXME: We should handle this more gracefully than force-unwrapping it.
                 lineNumber: Int(components[0])!,

--- a/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
+++ b/Sources/CartonHelpers/Parsers/DiagnosticsParser.swift
@@ -131,7 +131,8 @@ public struct DiagnosticsParser: ProcessOutputParser {
                       .trimmingCharacters(in: .whitespaces))) ??
                   .note,
                 file: file,
-                lineNumber: Int(components[0]),
+                // FIXME: We should handle this more gracefully than force-unwrapping it.
+                lineNumber: Int(components[0])!,
                 char: components[1],
                 code: String(lines[lineIdx]),
                 message: components.dropFirst(3).joined(separator: ":")
@@ -163,8 +164,8 @@ public struct DiagnosticsParser: ProcessOutputParser {
       var groupedMessages = [[CustomDiagnostic]]()
       for message in messages {
         if let finalLineNumber = groupedMessages.last?.last?.lineNumber,
-           let currentLineNumber = message.lineNumber,
-           finalLineNumber == currentLineNumber - 1 || finalLineNumber == currentLineNumber
+           // `message.lineNumber` is the current line number.
+           finalLineNumber == message.lineNumber - 1 || finalLineNumber == message.lineNumber
         {
           groupedMessages[groupedMessages.count - 1].append(message)
         } else {
@@ -181,10 +182,10 @@ public struct DiagnosticsParser: ProcessOutputParser {
             ) // 37;1: bright white
         }
         let greatestLineNumber = messages.map(\.lineNumber).max() ?? 0
-        let numberOfDigitsInGreatestLineNumber = {
+        let numberOfDigitsInGreatestLineNumber: Int = {
             let (quotient, remainder) = greatestLineNumber.quotientAndRemainder(dividingBy: 10)
             return quotient + (remainder == 0 ? 0 : 1)
-        }
+        }()
         for (offset, message) in messages.enumerated() {
           if offset > 0 {
             // Make sure we don't log the same line twice

--- a/Sources/CartonHelpers/Parsers/TestsParser.swift
+++ b/Sources/CartonHelpers/Parsers/TestsParser.swift
@@ -196,7 +196,7 @@ public struct TestsParser: ProcessOutputParser {
         let diag = DiagnosticsParser.CustomDiagnostic(
           kind: DiagnosticsParser.CustomDiagnostic.Kind(rawValue: String(status)) ?? .note,
           file: String(path),
-          line: lineNum,
+          lineNumber: lineNum,
           char: "0",
           code: "",
           message: String(problem)
@@ -255,7 +255,7 @@ public struct TestsParser: ProcessOutputParser {
             "\(testCase.name) \("(\(Int(Double(testCase.duration)! * 1000))ms)", color: "[90m")\n"
           ) // gray
         for problem in testCase.problems {
-          terminal.write("\n    \(problem.file, color: "[90m"):\(problem.line)\n")
+          terminal.write("\n    \(problem.file, color: "[90m"):\(problem.lineNumber)\n")
           terminal.write("    \(problem.message)\n\n")
           // Format XCTAssert functions
           for assertion in Regex.Assertion.allCases {
@@ -268,7 +268,7 @@ public struct TestsParser: ProcessOutputParser {
             }
           }
           // Get the line of code from the file and output it for context.
-          if let lineNum = Int(problem.line),
+          if let lineNum = Int(problem.lineNumber),
              lineNum > 0
           {
             var fileContents: String?
@@ -285,7 +285,7 @@ public struct TestsParser: ProcessOutputParser {
               let fileLines = fileContents.components(separatedBy: .newlines)
               guard fileLines.count >= lineNum else { break }
               let highlightedCode = Self.highlighter.highlight(String(fileLines[lineNum - 1]))
-              terminal.write("    \("\(problem.line) | ", color: "[36m")\(highlightedCode)\n")
+              terminal.write("    \("\(problem.lineNumber) | ", color: "[36m")\(highlightedCode)\n")
             }
           }
         }

--- a/Sources/CartonHelpers/Parsers/TestsParser.swift
+++ b/Sources/CartonHelpers/Parsers/TestsParser.swift
@@ -188,7 +188,8 @@ public struct TestsParser: ProcessOutputParser {
         )
       } else if let problem = line.matches(regex: Regex.problem),
                 let path = line.match(of: Regex.problem, labelled: .path),
-                let lineNum = line.match(of: Regex.problem, labelled: .line),
+				let lineNumberInBase10 = line.match(of: Regex.problem, labelled: .line),
+                let lineNumber = Int(lineNumberInBase10),
                 let status = line.match(of: Regex.problem, labelled: .status),
                 let suite = line.match(of: Regex.problem, labelled: .suite),
                 let testCase = line.match(of: Regex.problem, labelled: .testCase)
@@ -196,7 +197,7 @@ public struct TestsParser: ProcessOutputParser {
         let diag = DiagnosticsParser.CustomDiagnostic(
           kind: DiagnosticsParser.CustomDiagnostic.Kind(rawValue: String(status)) ?? .note,
           file: String(path),
-          lineNumber: lineNum,
+          lineNumber: lineNumber,
           char: "0",
           code: "",
           message: String(problem)
@@ -268,9 +269,7 @@ public struct TestsParser: ProcessOutputParser {
             }
           }
           // Get the line of code from the file and output it for context.
-          if let lineNum = Int(problem.lineNumber),
-             lineNum > 0
-          {
+		  if problem.lineNumber > 0 {
             var fileContents: String?
             if let fileBuf = fileBufs.first(where: { $0.path == problem.file })?.contents {
               fileContents = fileBuf
@@ -283,8 +282,8 @@ public struct TestsParser: ProcessOutputParser {
             }
             if let fileContents = fileContents {
               let fileLines = fileContents.components(separatedBy: .newlines)
-              guard fileLines.count >= lineNum else { break }
-              let highlightedCode = Self.highlighter.highlight(String(fileLines[lineNum - 1]))
+              guard fileLines.count >= problem.lineNumber else { break }
+              let highlightedCode = Self.highlighter.highlight(String(fileLines[problem.lineNumber - 1]))
               terminal.write("    \("\(problem.lineNumber) | ", color: "[36m")\(highlightedCode)\n")
             }
           }


### PR DESCRIPTION
I noticed a few problems with the pretty-printed diagnostics. 

Given a short Tokamak program as follows:

```swift
import TokamakShim

struct TokamakApp: App {
	var body: some Scene {
		WindowGroup("Tokamak App") {
			ContentView()
		}
	}
}

struct ContentView: View {
	var body: some View {
		VStack {
			Button("foo", action: nil)
			Button("字符串", action: nil)
		}
	}
}

Ni!

TokamakApp.main()
```

`carton dev` provides the following diagnosis:

<img width="523" alt="Screen Shot 2020-11-11 at 13 56 16" src="https://user-images.githubusercontent.com/55120045/98852453-b260a480-2425-11eb-98c8-946b2822f74b.png">

The most noticeable problem in the diagnostics is that the "^"s don't point to where the errors actually are. This pull request intends to address this problem by first stripping all leading whitespace in the pretty-printed source code, then copying any remaining whitespace verbatim to the indentation before each "^".

Some other problems include duplicated error messages and out-of-order diagnosis. I intend to address them in follow-up PRs.