### PR TITLE
Bump versions of libraries in `Template.swift`

### DIFF
--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -17,7 +17,7 @@ import Foundation
 import TSCBasic
 import TSCUtility
 
-public let compatibleJSKitVersion = Version(0, 8, 0)
+public let compatibleJSKitVersion = Version(0, 9, 0)
 
 enum ToolchainError: Error, CustomStringConvertible {
   case directoryDoesNotExist(AbsolutePath)

--- a/Sources/carton/Model/Template.swift
+++ b/Sources/carton/Model/Template.swift
@@ -179,7 +179,7 @@ extension Templates {
           .init(
             name: "Tokamak",
             url: "https://github.com/TokamakUI/Tokamak",
-            version: .from("0.5.1")
+            version: .from("0.6.0")
           ),
         ],
         targetDepencencies: [


### PR DESCRIPTION
Tokamak 0.6.0 is not released yet, but I will do it as soon as https://github.com/TokamakUI/Tokamak/pull/155 is approved.