### PR TITLE
Add support for Chrome and Safari stack traces

### DIFF
--- a/Sources/CartonHelpers/Parsers/ChromeStackTrace.swift
+++ b/Sources/CartonHelpers/Parsers/ChromeStackTrace.swift
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-//  Created by Max Desiatov on 08/11/2020.
+//  Created by Jed Fox on 12/6/20.
 //
 
 import TSCBasic
 
 // swiftlint:disable force_try
-fileprivate let webpackRegex = try! RegEx(pattern: "(.+)@webpack:///(.+)")
-fileprivate let wasmRegex = try! RegEx(pattern: "(.+)@http://127.0.0.1.+WebAssembly.instantiate:(.+)")
+fileprivate let webpackRegex = try! RegEx(pattern: "at (.+) \\(webpack:///(.+?)\\)")
+fileprivate let wasmRegex = try! RegEx(pattern: "at (.+) \\(<anonymous>:(.+?)\\)")
 // swiftlint:enable force_try
 
 public extension StringProtocol {
-  var firefoxStackTrace: [StackTraceItem] {
-    split(separator: "\n").compactMap {
+  var chromeStackTrace: [StackTraceItem] {
+    split(separator: "\n").dropFirst().compactMap {
       if let webpackMatch = webpackRegex.matchGroups(in: String($0)).first,
          let symbol = webpackMatch.first,
          let location = webpackMatch.last
@@ -46,3 +46,4 @@ public extension StringProtocol {
     }
   }
 }
+

--- a/Sources/CartonHelpers/Parsers/ChromeStackTrace.swift
+++ b/Sources/CartonHelpers/Parsers/ChromeStackTrace.swift
@@ -18,8 +18,8 @@
 import TSCBasic
 
 // swiftlint:disable force_try
-fileprivate let webpackRegex = try! RegEx(pattern: "at (.+) \\(webpack:///(.+?)\\)")
-fileprivate let wasmRegex = try! RegEx(pattern: "at (.+) \\(<anonymous>:(.+?)\\)")
+private let webpackRegex = try! RegEx(pattern: "at (.+) \\(webpack:///(.+?)\\)")
+private let wasmRegex = try! RegEx(pattern: "at (.+) \\(<anonymous>:(.+?)\\)")
 // swiftlint:enable force_try
 
 public extension StringProtocol {
@@ -46,4 +46,3 @@ public extension StringProtocol {
     }
   }
 }
-

--- a/Sources/CartonHelpers/Parsers/FirefoxStackTrace.swift
+++ b/Sources/CartonHelpers/Parsers/FirefoxStackTrace.swift
@@ -18,8 +18,8 @@
 import TSCBasic
 
 // swiftlint:disable force_try
-fileprivate let webpackRegex = try! RegEx(pattern: "(.+)@webpack:///(.+)")
-fileprivate let wasmRegex = try! RegEx(pattern: "(.+)@http://127.0.0.1.+WebAssembly.instantiate:(.+)")
+private let webpackRegex = try! RegEx(pattern: "(.+)@webpack:///(.+)")
+private let wasmRegex = try! RegEx(pattern: "(.+)@http://127.0.0.1.+WebAssembly.instantiate:(.+)")
 // swiftlint:enable force_try
 
 public extension StringProtocol {

--- a/Sources/CartonHelpers/Parsers/SafariStackTrace.swift
+++ b/Sources/CartonHelpers/Parsers/SafariStackTrace.swift
@@ -18,8 +18,8 @@
 import TSCBasic
 
 // swiftlint:disable force_try
-fileprivate let jsRegex = try! RegEx(pattern: "(.+?)(?:@(?:\\[(?:native|wasm) code\\]|(.+)))?$")
-fileprivate let wasmRegex = try! RegEx(pattern: "<\\?>\\.wasm-function\\[(.+)\\]@\\[wasm code\\]")
+private let jsRegex = try! RegEx(pattern: "(.+?)(?:@(?:\\[(?:native|wasm) code\\]|(.+)))?$")
+private let wasmRegex = try! RegEx(pattern: "<\\?>\\.wasm-function\\[(.+)\\]@\\[wasm code\\]")
 // swiftlint:enable force_try
 
 public extension StringProtocol {

--- a/Sources/CartonHelpers/StackTrace.swift
+++ b/Sources/CartonHelpers/StackTrace.swift
@@ -56,6 +56,6 @@ public struct StackTraceItem: Equatable {
   }
 
   public let symbol: String
-  public let location: String
+  public let location: String?
   public let kind: Kind
 }

--- a/Sources/SwiftToolchain/DestinationEnvironment.swift
+++ b/Sources/SwiftToolchain/DestinationEnvironment.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import CartonHelpers
+
 public enum DestinationEnvironment {
   case other
   case safari
@@ -19,4 +21,16 @@ public enum DestinationEnvironment {
   case chrome
   case edge
   case browser
+}
+
+public extension String {
+  func parsedStackTrace(in environment: DestinationEnvironment) -> [StackTraceItem]? {
+    switch environment {
+    case .safari: return safariStackTrace
+    case .firefox: return firefoxStackTrace
+    case .chrome: return chromeStackTrace
+    case .edge: return chromeStackTrace // TODO: return nil if on old Edge
+    default: return nil
+    }
+  }
 }

--- a/Sources/carton/Server/Server.swift
+++ b/Sources/carton/Server/Server.swift
@@ -125,14 +125,18 @@ final class Server {
 
             switch event {
             case let .stackTrace(rawStackTrace):
-              guard environment == .firefox else { break }
-
-              let stackTrace = rawStackTrace.firefoxStackTrace
-
-              terminal.write("\nAn error occurred, here's a stack trace for it:\n", inColor: .red)
-              stackTrace.forEach { item in
-                terminal.write("  \(item.symbol)", inColor: .cyan)
-                terminal.write(" at \(item.location)\n", inColor: .grey)
+              if let stackTrace = rawStackTrace.parsedStackTrace(in: environment) {
+                terminal.write("\nAn error occurred, here's a stack trace for it:\n", inColor: .red)
+                stackTrace.forEach { item in
+                  terminal.write("  \(item.symbol)", inColor: .cyan)
+                  terminal.write(" at \(item.location ?? "<unknown>")\n", inColor: .grey)
+                }
+              } else {
+                terminal.write("\nAn error occurred, here's the raw stack trace for it:\n", inColor: .red)
+                terminal.write("  Please send an issue or PR to the Carton repository\n" +
+                               "  with your browser name and this raw stack trace so\n" +
+                               "  we can add support for it.\n", inColor: .grey)
+                terminal.write(rawStackTrace + "\n")
               }
             case let .testRunOutput(output):
               TestsParser().parse(output, terminal)

--- a/Sources/carton/Server/Server.swift
+++ b/Sources/carton/Server/Server.swift
@@ -115,37 +115,12 @@ final class Server {
         product: configuration.product,
         entrypoint: configuration.entrypoint,
         onWebSocketOpen: { [weak self] ws, environment in
-          ws.onText { _, text in
-            guard
-              let data = text.data(using: .utf8),
-              let event = try? self?.decoder.decode(Event.self, from: data)
-            else {
-              return
-            }
-
-            switch event {
-            case let .stackTrace(rawStackTrace):
-              if let stackTrace = rawStackTrace.parsedStackTrace(in: environment) {
-                terminal.write("\nAn error occurred, here's a stack trace for it:\n", inColor: .red)
-                stackTrace.forEach { item in
-                  terminal.write("  \(item.symbol)", inColor: .cyan)
-                  terminal.write(" at \(item.location ?? "<unknown>")\n", inColor: .grey)
-                }
-              } else {
-                terminal.write("\nAn error occurred, here's the raw stack trace for it:\n", inColor: .red)
-                terminal.write("  Please send an issue or PR to the Carton repository\n" +
-                               "  with your browser name and this raw stack trace so\n" +
-                               "  we can add support for it.\n", inColor: .grey)
-                terminal.write(rawStackTrace + "\n")
-              }
-            case let .testRunOutput(output):
-              TestsParser().parse(output, terminal)
-
-              // Test run finished, no need to keep the server running anymore.
-              if configuration.builder == nil {
-                kill(getpid(), SIGINT)
-              }
-            }
+          if let handler = self?.createWSHandler(
+            with: configuration,
+            in: environment,
+            terminal: terminal
+          ) {
+            ws.onText(handler)
           }
           self?.connections.insert(ws)
         },
@@ -199,6 +174,48 @@ final class Server {
       })
       .catch { _ in Empty().eraseToAnyPublisher() }
       .eraseToAnyPublisher()
+  }
+}
+
+extension Server {
+  func createWSHandler(
+    with configuration: Configuration,
+    in environment: DestinationEnvironment,
+    terminal: InteractiveWriter
+  ) -> (WebSocket, String) -> () {
+    { [weak self] _, text in
+      guard
+        let data = text.data(using: .utf8),
+        let event = try? self?.decoder.decode(Event.self, from: data)
+      else {
+        return
+      }
+
+      switch event {
+      case let .stackTrace(rawStackTrace):
+        if let stackTrace = rawStackTrace.parsedStackTrace(in: environment) {
+          terminal.write("\nAn error occurred, here's a stack trace for it:\n", inColor: .red)
+          stackTrace.forEach { item in
+            terminal.write("  \(item.symbol)", inColor: .cyan)
+            terminal.write(" at \(item.location ?? "<unknown>")\n", inColor: .grey)
+          }
+        } else {
+          terminal.write("\nAn error occurred, here's the raw stack trace for it:\n", inColor: .red)
+          terminal.write("  Please send an issue or PR to the Carton repository\n" +
+            "  with your browser name and this raw stack trace so\n" +
+            "  we can add support for it.\n", inColor: .grey)
+          terminal.write(rawStackTrace + "\n")
+        }
+
+      case let .testRunOutput(output):
+        TestsParser().parse(output, terminal)
+
+        // Test run finished, no need to keep the server running anymore.
+        if configuration.builder == nil {
+          kill(getpid(), SIGINT)
+        }
+      }
+    }
   }
 }
 

--- a/Tests/CartonTests/StackTraceTests.swift
+++ b/Tests/CartonTests/StackTraceTests.swift
@@ -48,111 +48,414 @@ final class StackTraceTests: XCTestCase {
     swjs_create_function/func_ref<@webpack:///./node_modules/javascript-kit-swift/Runtime/lib/index.js?:280:28
     """.firefoxStackTrace
 
-    XCTAssertEqual(
-      stackTrace,
+    let expected: [StackTraceItem] = [
+      .init(
+        symbol: "wasmFs.fs.writeSync",
+        location: "./entrypoint/dev.js?:35:21",
+        kind: .javaScript
+      ),
+      .init(
+        symbol: "a/this.wasiImport.fd_write</<",
+        location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:115:429",
+        kind: .javaScript
+      ),
+      .init(
+        symbol: "a/this.wasiImport.fd_write<",
+        location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:115:372",
+        kind: .javaScript
+      ),
+      .init(
+        symbol: "Z/<",
+        location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:102:271",
+        kind: .javaScript
+      ),
+      .init(
+        symbol: "write",
+        location: "wasm-function[62062]:0x12af331",
+        kind: .webAssembly
+      ), .init(
+        symbol: "swift_reportError",
+        location: "wasm-function[21654]:0x37c242",
+        kind: .webAssembly
+      ), .init(
+        symbol: "_swift_stdlib_reportFatalErrorInFile",
+        location: "wasm-function[22950]:0x3e2996",
+        kind: .webAssembly
+      ), .init(
+        symbol: "closure #1 (UnsafeBufferPointer<UInt8>) -> () in closure #1 (UnsafeBufferPointer<UInt8>) -> () in _assertionFailure(_: StaticString, _: StaticString, file: StaticString, line: UInt, flags: UInt32) -> Never",
+        location: "wasm-function[3635]:0xd717d",
+        kind: .webAssembly
+      ), .init(
+        symbol: "merged closure #1 (UnsafeBufferPointer<UInt8>) -> () in _assertionFailure(_: StaticString, _: StaticString, file: StaticString, line: UInt, flags: UInt32) -> Never",
+        location: "wasm-function[3636]:0xd7374",
+        kind: .webAssembly
+      ), .init(
+        symbol: "Swift._assertionFailure(_: StaticString, _: StaticString, file: StaticString, line: UInt, flags: UInt32) -> Never",
+        location: "wasm-function[2752]:0xa7917",
+        kind: .webAssembly
+      ), .init(
+        symbol: "Swift.Array.subscript.getter : (Int) -> A",
+        location: "wasm-function[2982]:0xb34da",
+        kind: .webAssembly
+      ), .init(
+        symbol: "TestApp.crash() -> ()",
+        location: "wasm-function[1372]:0x8012c",
+        kind: .webAssembly
+      ), .init(
+        symbol: "closure #1 (Array<JavaScriptKit.JSValue>) -> () in TestApp",
+        location: "wasm-function[1367]:0x7f4e7",
+        kind: .webAssembly
+      ), .init(
+        symbol: "closure #1 (Array<JavaScriptKit.JSValue>) -> JavaScriptKit.JSValue in JavaScriptKit.JSClosure.init((Array<JavaScriptKit.JSValue>) -> ()) -> JavaScriptKit.JSClosure",
+        location: "wasm-function[787]:0x5003b",
+        kind: .webAssembly
+      ), .init(
+        symbol: "partial apply forwarder for closure #1 (Array<JavaScriptKit.JSValue>) -> JavaScriptKit.JSValue in JavaScriptKit.JSClosure.init((Array<JavaScriptKit.JSValue>) -> ()) -> JavaScriptKit.JSClosure",
+        location: "wasm-function[786]:0x4ff96",
+        kind: .webAssembly
+      ), .init(
+        symbol: "reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue)",
+        location: "wasm-function[783]:0x4fe00",
+        kind: .webAssembly
+      ), .init(
+        symbol: "partial apply forwarder for reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue)",
+        location: "wasm-function[782]:0x4fdc8",
+        kind: .webAssembly
+      ), .init(
+        symbol: "reabstraction thunk helper from @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue)",
+        location: "wasm-function[812]:0x52ddd",
+        kind: .webAssembly
+      ), .init(
+        symbol: "partial apply forwarder for reabstraction thunk helper from @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue)",
+        location: "wasm-function[802]:0x529bc",
+        kind: .webAssembly
+      ), .init(
+        symbol: "JavaScriptKit._call_host_function_impl(UInt32, UnsafePointer<__C.RawJSValue>, Int32, UInt32) -> ()",
+        location: "wasm-function[801]:0x525e8",
+        kind: .webAssembly
+      ), .init(
+        symbol: "_call_host_function_impl",
+        location: "wasm-function[800]:0x52158",
+        kind: .webAssembly
+      ), .init(
+        symbol: "_call_host_function",
+        location: "wasm-function[1388]:0x814d3",
+        kind: .webAssembly
+      ), .init(
+        symbol: "callHostFunction",
+        location: "./node_modules/javascript-kit-swift/Runtime/lib/index.js?:110:21",
+        kind: .javaScript
+      ), .init(
+        symbol: "swjs_create_function/func_ref<",
+        location: "./node_modules/javascript-kit-swift/Runtime/lib/index.js?:280:28",
+        kind: .javaScript
+      ),
+    ]
+    XCTAssertEqual(stackTrace, expected)
+  }
+
+  func testSafariStackTrace() {
+    // swiftlint:disable line_length
+    let stackTrace = """
+    forEach@[native code]
+
+
+    wasm-stub@[wasm code]
+    <?>.wasm-function[write]@[wasm code]
+    <?>.wasm-function[swift_reportError]@[wasm code]
+    <?>.wasm-function[_swift_stdlib_reportFatalErrorInFile]@[wasm code]
+    <?>.wasm-function[$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtFySRys5UInt8VGXEfU_yAMXEfU_]@[wasm code]
+    <?>.wasm-function[$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtFySRys5UInt8VGXEfU_Tm]@[wasm code]
+    <?>.wasm-function[$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF]@[wasm code]
+    <?>.wasm-function[$sSayxSicig]@[wasm code]
+    <?>.wasm-function[$s7TestApp5crashyyF]@[wasm code]
+    <?>.wasm-function[$s7TestAppySay13JavaScriptKit7JSValueOGcfU_]@[wasm code]
+    <?>.wasm-function[$s13JavaScriptKit9JSClosureCyACySayAA7JSValueOGccfcAeFcfU_]@[wasm code]
+    <?>.wasm-function[$s13JavaScriptKit9JSClosureCyACySayAA7JSValueOGccfcAeFcfU_TA]@[wasm code]
+    <?>.wasm-function[$sSay13JavaScriptKit7JSValueOGACIeggo_AdCIegnr_TR]@[wasm code]
+    <?>.wasm-function[$sSay13JavaScriptKit7JSValueOGACIeggo_AdCIegnr_TRTA]@[wasm code]
+    <?>.wasm-function[$sSay13JavaScriptKit7JSValueOGACIegnr_AdCIeggo_TR]@[wasm code]
+    <?>.wasm-function[$sSay13JavaScriptKit7JSValueOGACIegnr_AdCIeggo_TRTA]@[wasm code]
+    <?>.wasm-function[$s13JavaScriptKit24_call_host_function_implyys6UInt32V_SPySo10RawJSValueaGs5Int32VADtF]@[wasm code]
+    <?>.wasm-function[_call_host_function_impl]@[wasm code]
+    <?>.wasm-function[_call_host_function]@[wasm code]
+    wasm-stub@[wasm code]
+    swjs_call_host_function@[native code]
+    callHostFunction
+    """.safariStackTrace
+
+    let expected: [StackTraceItem] =
+      [
+//        .init(
+//          symbol: "wasmFs.fs.writeSync",
+//          location: "./entrypoint/dev.js?:35:21",
+//          kind: .javaScript
+//        ),
+//        .init(
+//          symbol: "a/this.wasiImport.fd_write</<",
+//          location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:115:429",
+//          kind: .javaScript
+//        ),
+//        .init(
+//          symbol: "a/this.wasiImport.fd_write<",
+//          location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:115:372",
+//          kind: .javaScript
+//        ),
+//        .init(
+//          symbol: "Z/<",
+//          location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:102:271",
+//          kind: .javaScript
+//        ),
+//        .init(
+//          symbol: "write",
+//          location: "wasm-function[62062]:0x12af331",
+//          kind: .webAssembly
+//        ), .init(
+//          symbol: "swift_reportError",
+//          location: "wasm-function[21654]:0x37c242",
+//          kind: .webAssembly
+//        ), .init(
+//          symbol: "_swift_stdlib_reportFatalErrorInFile",
+//          location: "wasm-function[22950]:0x3e2996",
+//          kind: .webAssembly
+//        ),
+        .init(
+          symbol: "forEach",
+          location: nil,
+          kind: .javaScript
+        ), .init(
+          symbol: "wasm-stub",
+          location: nil,
+          kind: .javaScript
+        ), .init(
+          symbol: "write",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "swift_reportError",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "_swift_stdlib_reportFatalErrorInFile",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "closure #1 (UnsafeBufferPointer<UInt8>) -> () in closure #1 (UnsafeBufferPointer<UInt8>) -> () in _assertionFailure(_: StaticString, _: StaticString, file: StaticString, line: UInt, flags: UInt32) -> Never",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "merged closure #1 (UnsafeBufferPointer<UInt8>) -> () in _assertionFailure(_: StaticString, _: StaticString, file: StaticString, line: UInt, flags: UInt32) -> Never",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "Swift._assertionFailure(_: StaticString, _: StaticString, file: StaticString, line: UInt, flags: UInt32) -> Never",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "Swift.Array.subscript.getter : (Int) -> A",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "TestApp.crash() -> ()",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "closure #1 (Array<JavaScriptKit.JSValue>) -> () in TestApp",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "closure #1 (Array<JavaScriptKit.JSValue>) -> JavaScriptKit.JSValue in JavaScriptKit.JSClosure.init((Array<JavaScriptKit.JSValue>) -> ()) -> JavaScriptKit.JSClosure",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "partial apply forwarder for closure #1 (Array<JavaScriptKit.JSValue>) -> JavaScriptKit.JSValue in JavaScriptKit.JSClosure.init((Array<JavaScriptKit.JSValue>) -> ()) -> JavaScriptKit.JSClosure",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue)",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "partial apply forwarder for reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue)",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "reabstraction thunk helper from @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue)",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "partial apply forwarder for reabstraction thunk helper from @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue)",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "JavaScriptKit._call_host_function_impl(UInt32, UnsafePointer<__C.RawJSValue>, Int32, UInt32) -> ()",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "_call_host_function_impl",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "_call_host_function",
+          location: nil,
+          kind: .webAssembly
+        ), .init(
+          symbol: "wasm-stub",
+          location: nil,
+          kind: .javaScript
+        ), .init(
+          symbol: "swjs_call_host_function",
+          location: nil,
+          kind: .javaScript
+        ), .init(
+          symbol: "callHostFunction",
+          location: nil,
+          kind: .javaScript
+        ),
+//        .init(
+//          symbol: "swjs_create_function/func_ref<",
+//          location: nil,
+//          kind: .javaScript
+//        ),
+      ]
+    XCTAssertEqual(stackTrace, expected)
+  }
+
+  func testChromeStackTrace() {
+    // swiftlint:disable line_length
+    let stackTrace = """
+    Error
+        at Object.wasmFs.fs.writeSync (webpack:///./entrypoint/dev.js?:54:25)
+        at eval (webpack:///./node_modules/@wasmer/wasi/lib/index.esm.js?:115:429)
+        at Array.forEach (<anonymous>)
+        at eval (webpack:///./node_modules/@wasmer/wasi/lib/index.esm.js?:115:372)
+        at eval (webpack:///./node_modules/@wasmer/wasi/lib/index.esm.js?:102:271)
+        at write (<anonymous>:wasm-function[62105]:0x12b19bc)
+        at swift_reportError (<anonymous>:wasm-function[21697]:0x37e8aa)
+        at _swift_stdlib_reportFatalErrorInFile (<anonymous>:wasm-function[22993]:0x3e4ffe)
+        at $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtFySRys5UInt8VGXEfU_yAMXEfU_ (<anonymous>:wasm-function[3676]:0xd96fc)
+        at $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtFySRys5UInt8VGXEfU_Tm (<anonymous>:wasm-function[3677]:0xd98f3)
+        at $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF (<anonymous>:wasm-function[2793]:0xa9f38)
+        at $sSayxSicig (<anonymous>:wasm-function[3023]:0xb5afb)
+        at $s7TestApp5crashyyF (<anonymous>:wasm-function[1413]:0x8274d)
+        at $s7TestAppySay13JavaScriptKit7JSValueOGcfU_ (<anonymous>:wasm-function[1408]:0x81b08)
+        at $s13JavaScriptKit9JSClosureCyACySayAA7JSValueOGccfcAeFcfU_ (<anonymous>:wasm-function[816]:0x51881)
+        at $s13JavaScriptKit9JSClosureCyACySayAA7JSValueOGccfcAeFcfU_TA (<anonymous>:wasm-function[815]:0x517dc)
+        at $sSay13JavaScriptKit7JSValueOGACIeggo_AdCIegnr_TR (<anonymous>:wasm-function[812]:0x51646)
+        at $sSay13JavaScriptKit7JSValueOGACIeggo_AdCIegnr_TRTA (<anonymous>:wasm-function[811]:0x5160e)
+        at $sSay13JavaScriptKit7JSValueOGACIegnr_AdCIeggo_TR (<anonymous>:wasm-function[839]:0x54566)
+        at $sSay13JavaScriptKit7JSValueOGACIegnr_AdCIeggo_TRTA (<anonymous>:wasm-function[831]:0x54202)
+        at $s13JavaScriptKit24_call_host_function_implyys6UInt32V_SPySo10RawJSValueaGs5Int32VADtF (<anonymous>:wasm-function[830]:0x53e2e)
+        at _call_host_function_impl (<anonymous>:wasm-function[829]:0x5399e)
+        at _call_host_function (<anonymous>:wasm-function[1429]:0x83af4)
+        at callHostFunction (webpack:///./node_modules/javascript-kit-swift/Runtime/lib/index.js?:110:21)
+        at HTMLButtonElement.eval (webpack:///./node_modules/javascript-kit-swift/Runtime/lib/index.js?:295:28)
+    """.chromeStackTrace
+
+    let expected: [StackTraceItem] =
       [
         .init(
-          symbol: "wasmFs.fs.writeSync",
-          location: "./entrypoint/dev.js?:35:21",
+          symbol: "Object.wasmFs.fs.writeSync",
+          location: "./entrypoint/dev.js?:54:25",
           kind: .javaScript
         ),
         .init(
-          symbol: "a/this.wasiImport.fd_write</<",
+          symbol: "eval",
           location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:115:429",
           kind: .javaScript
         ),
         .init(
-          symbol: "a/this.wasiImport.fd_write<",
+          symbol: "eval",
           location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:115:372",
           kind: .javaScript
         ),
         .init(
-          symbol: "Z/<",
+          symbol: "eval",
           location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:102:271",
           kind: .javaScript
         ),
         .init(
           symbol: "write",
-          location: "wasm-function[62062]:0x12af331",
+          location: "wasm-function[62105]:0x12b19bc",
           kind: .webAssembly
         ), .init(
           symbol: "swift_reportError",
-          location: "wasm-function[21654]:0x37c242",
+          location: "wasm-function[21697]:0x37e8aa",
           kind: .webAssembly
         ), .init(
           symbol: "_swift_stdlib_reportFatalErrorInFile",
-          location: "wasm-function[22950]:0x3e2996",
+          location: "wasm-function[22993]:0x3e4ffe",
           kind: .webAssembly
         ), .init(
           symbol: "closure #1 (UnsafeBufferPointer<UInt8>) -> () in closure #1 (UnsafeBufferPointer<UInt8>) -> () in _assertionFailure(_: StaticString, _: StaticString, file: StaticString, line: UInt, flags: UInt32) -> Never",
-          location: "wasm-function[3635]:0xd717d",
+          location: "wasm-function[3676]:0xd96fc",
           kind: .webAssembly
         ), .init(
           symbol: "merged closure #1 (UnsafeBufferPointer<UInt8>) -> () in _assertionFailure(_: StaticString, _: StaticString, file: StaticString, line: UInt, flags: UInt32) -> Never",
-          location: "wasm-function[3636]:0xd7374",
+          location: "wasm-function[3677]:0xd98f3",
           kind: .webAssembly
         ), .init(
           symbol: "Swift._assertionFailure(_: StaticString, _: StaticString, file: StaticString, line: UInt, flags: UInt32) -> Never",
-          location: "wasm-function[2752]:0xa7917",
+          location: "wasm-function[2793]:0xa9f38",
           kind: .webAssembly
         ), .init(
           symbol: "Swift.Array.subscript.getter : (Int) -> A",
-          location: "wasm-function[2982]:0xb34da",
+          location: "wasm-function[3023]:0xb5afb",
           kind: .webAssembly
         ), .init(
           symbol: "TestApp.crash() -> ()",
-          location: "wasm-function[1372]:0x8012c",
+          location: "wasm-function[1413]:0x8274d",
           kind: .webAssembly
         ), .init(
           symbol: "closure #1 (Array<JavaScriptKit.JSValue>) -> () in TestApp",
-          location: "wasm-function[1367]:0x7f4e7",
+          location: "wasm-function[1408]:0x81b08",
           kind: .webAssembly
         ), .init(
           symbol: "closure #1 (Array<JavaScriptKit.JSValue>) -> JavaScriptKit.JSValue in JavaScriptKit.JSClosure.init((Array<JavaScriptKit.JSValue>) -> ()) -> JavaScriptKit.JSClosure",
-          location: "wasm-function[787]:0x5003b",
+          location: "wasm-function[816]:0x51881",
           kind: .webAssembly
         ), .init(
           symbol: "partial apply forwarder for closure #1 (Array<JavaScriptKit.JSValue>) -> JavaScriptKit.JSValue in JavaScriptKit.JSClosure.init((Array<JavaScriptKit.JSValue>) -> ()) -> JavaScriptKit.JSClosure",
-          location: "wasm-function[786]:0x4ff96",
+          location: "wasm-function[815]:0x517dc",
           kind: .webAssembly
         ), .init(
           symbol: "reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue)",
-          location: "wasm-function[783]:0x4fe00",
+          location: "wasm-function[812]:0x51646",
           kind: .webAssembly
         ), .init(
           symbol: "partial apply forwarder for reabstraction thunk helper from @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue)",
-          location: "wasm-function[782]:0x4fdc8",
+          location: "wasm-function[811]:0x5160e",
           kind: .webAssembly
         ), .init(
           symbol: "reabstraction thunk helper from @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue)",
-          location: "wasm-function[812]:0x52ddd",
+          location: "wasm-function[839]:0x54566",
           kind: .webAssembly
         ), .init(
           symbol: "partial apply forwarder for reabstraction thunk helper from @escaping @callee_guaranteed (@in_guaranteed Array<JavaScriptKit.JSValue>) -> (@out JavaScriptKit.JSValue) to @escaping @callee_guaranteed (@guaranteed Array<JavaScriptKit.JSValue>) -> (@owned JavaScriptKit.JSValue)",
-          location: "wasm-function[802]:0x529bc",
+          location: "wasm-function[831]:0x54202",
           kind: .webAssembly
         ), .init(
           symbol: "JavaScriptKit._call_host_function_impl(UInt32, UnsafePointer<__C.RawJSValue>, Int32, UInt32) -> ()",
-          location: "wasm-function[801]:0x525e8",
+          location: "wasm-function[830]:0x53e2e",
           kind: .webAssembly
         ), .init(
           symbol: "_call_host_function_impl",
-          location: "wasm-function[800]:0x52158",
+          location: "wasm-function[829]:0x5399e",
           kind: .webAssembly
         ), .init(
           symbol: "_call_host_function",
-          location: "wasm-function[1388]:0x814d3",
+          location: "wasm-function[1429]:0x83af4",
           kind: .webAssembly
         ), .init(
           symbol: "callHostFunction",
           location: "./node_modules/javascript-kit-swift/Runtime/lib/index.js?:110:21",
           kind: .javaScript
         ), .init(
-          symbol: "swjs_create_function/func_ref<",
-          location: "./node_modules/javascript-kit-swift/Runtime/lib/index.js?:280:28",
+          symbol: "HTMLButtonElement.eval",
+          location: "./node_modules/javascript-kit-swift/Runtime/lib/index.js?:295:28",
           kind: .javaScript
         ),
       ]
-    )
+    XCTAssertEqual(stackTrace, expected)
   }
 }

--- a/Tests/CartonTests/StackTraceTests.swift
+++ b/Tests/CartonTests/StackTraceTests.swift
@@ -188,39 +188,6 @@ extension StackTraceTests {
 
     let expected: [StackTraceItem] =
       [
-//        .init(
-//          symbol: "wasmFs.fs.writeSync",
-//          location: "./entrypoint/dev.js?:35:21",
-//          kind: .javaScript
-//        ),
-//        .init(
-//          symbol: "a/this.wasiImport.fd_write</<",
-//          location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:115:429",
-//          kind: .javaScript
-//        ),
-//        .init(
-//          symbol: "a/this.wasiImport.fd_write<",
-//          location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:115:372",
-//          kind: .javaScript
-//        ),
-//        .init(
-//          symbol: "Z/<",
-//          location: "./node_modules/@wasmer/wasi/lib/index.esm.js?:102:271",
-//          kind: .javaScript
-//        ),
-//        .init(
-//          symbol: "write",
-//          location: "wasm-function[62062]:0x12af331",
-//          kind: .webAssembly
-//        ), .init(
-//          symbol: "swift_reportError",
-//          location: "wasm-function[21654]:0x37c242",
-//          kind: .webAssembly
-//        ), .init(
-//          symbol: "_swift_stdlib_reportFatalErrorInFile",
-//          location: "wasm-function[22950]:0x3e2996",
-//          kind: .webAssembly
-//        ),
         .init(
           symbol: "forEach",
           location: nil,
@@ -314,11 +281,6 @@ extension StackTraceTests {
           location: nil,
           kind: .javaScript
         ),
-//        .init(
-//          symbol: "swjs_create_function/func_ref<",
-//          location: nil,
-//          kind: .javaScript
-//        ),
       ]
     XCTAssertEqual(stackTrace, expected)
   }

--- a/Tests/CartonTests/StackTraceTests.swift
+++ b/Tests/CartonTests/StackTraceTests.swift
@@ -18,7 +18,8 @@
 @testable import CartonHelpers
 import XCTest
 
-final class StackTraceTests: XCTestCase {
+final class StackTraceTests: XCTestCase {}
+extension StackTraceTests {
   func testFirefoxStackTrace() {
     // swiftlint:disable line_length
     let stackTrace = """
@@ -153,7 +154,8 @@ final class StackTraceTests: XCTestCase {
     ]
     XCTAssertEqual(stackTrace, expected)
   }
-
+}
+extension StackTraceTests {
   func testSafariStackTrace() {
     // swiftlint:disable line_length
     let stackTrace = """
@@ -320,7 +322,8 @@ final class StackTraceTests: XCTestCase {
       ]
     XCTAssertEqual(stackTrace, expected)
   }
-
+}
+extension StackTraceTests {
   func testChromeStackTrace() {
     // swiftlint:disable line_length
     let stackTrace = """

--- a/entrypoint/dev.js
+++ b/entrypoint/dev.js
@@ -40,12 +40,15 @@ wasmFs.fs.writeSync = (fd, buffer, offset, length, position) => {
         break;
       case 2:
         console.error(text);
+        const prevLimit = Error.stackTraceLimit;
+        Error.stackTraceLimit = 1000
         socket.send(
           JSON.stringify({
             kind: "stackTrace",
             stackTrace: new Error().stack,
           })
         );
+        Error.stackTraceLimit = prevLimit;
         break;
     }
   }


### PR DESCRIPTION
I made `location` optional because Safari doesn’t report it for some reason. There’s a bit of duplication between the stack trace parsers but I don’t think that’s a big problem.


I’ve also changed the behavior to log when an error occurs in an unsupported browser, and to provide a sample stack trace that we can attempt to parse.