### PR TITLE
Avoid running tests while building the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ COPY . carton/
 RUN cd carton && \
   ./install_ubuntu_deps.sh && \
   swift build -c release --build-tests --enable-test-discovery && \
-  swift test -c release --enable-test-discovery && \
   mv .build/release/carton /usr/bin && \
   cd .. && \
   rm -rf carton /tmp/wasmer*


### PR DESCRIPTION
We already run these tests on Ubuntu as a part of separate CI jobs.