### PR TITLE
[NFC] Remove `Project.inPlace` to simplify package init logic

### DIFF
--- a/Sources/CartonCLI/Commands/Init.swift
+++ b/Sources/CartonCLI/Commands/Init.swift
@@ -25,43 +25,85 @@ struct Init: ParsableCommand {
     subcommands: [ListTemplates.self]
   )
 
-  @Option(name: .long,
-          help: "The template to base the project on.",
-          transform: { Templates(rawValue: $0.lowercased()) })
+  @Option(
+    name: .long,
+    help: "The template to base the project on.",
+    transform: { Templates(rawValue: $0.lowercased()) }
+  )
   var template: Templates?
 
-  @Option(name: .long,
-          help: "The name of the project") var name: String?
+  @Option(
+    name: .long,
+    help: """
+          The name of the project, if it's different from the current working directory's name.
+          If this option is set, carton will create the package for the project in a subdirectory by the given name.
+          Otherwise, the package will be created in the current working directory, with the package named after the directory's.
+          """
+  )
+  var name: String?
 
   func run() throws {
     let terminal = InteractiveWriter.stdout
 
-    guard let name = name ?? localFileSystem.currentWorkingDirectory?.basename else {
-      terminal.write("Project name could not be inferred\n", inColor: .red)
-      return
+    guard let currentDirectory = localFileSystem.currentWorkingDirectory else {
+      throw ProjectInitialisationError.cannotFindCurrentDirectory
     }
-    guard let currentDir = localFileSystem.currentWorkingDirectory else {
-      terminal.write("Failed to get current working directory.\n", inColor: .red)
-      return
-    }
+
+    /// The kind of template the project is to be created with.
+    /// - Note: This value is of the type `Templates`, not `Template`.
     let template = self.template ?? .basic
+
+    let projectName = name ?? currentDirectory.basename
+    let projectPath = name == nil ? currentDirectory : currentDirectory.appending(component: projectName)
+    
+    // FIXME: Replace with `NSString.abbreviatingWithTildeInPath`?
+    let packagePathRelativeToHomeDirectory = projectPath.relative(to: localFileSystem.homeDirectory)
+
     terminal.write("Creating new project with template ")
     terminal.write("\(template.rawValue)", inColor: .green)
     terminal.write(" in ")
-    terminal.write("\(name)\n", inColor: .cyan)
+    terminal.write("~/\(packagePathRelativeToHomeDirectory.pathString)\n", inColor: .cyan)
 
-    guard let packagePath = self.name == nil ?
-      localFileSystem.currentWorkingDirectory :
-      AbsolutePath(name, relativeTo: currentDir)
-    else {
-      terminal.write("Path to project could be created.\n", inColor: .red)
-      return
+    do {
+      // `LocalFileSystem.createDirectory` wraps `FileManager.createDirectory`, which throws an NSError.
+      try localFileSystem.createDirectory(projectPath)
+    } catch let nsError as NSError {
+        throw ProjectInitialisationError.cannotCreateDirectory(path: packagePathRelativeToHomeDirectory, reason: nsError.localizedDescription)
     }
-    try localFileSystem.createDirectory(packagePath)
-    try template.template.create(
-      on: localFileSystem,
-      project: .init(name: name, path: packagePath, inPlace: self.name == nil),
-      terminal
-    )
+    
+    // FIXME: Handle this error-catching in each `Template.create()` instead.
+    do {
+      // FIXME:  The first `template` is of type `Templates`, and two consecutive `template` looks odd.
+      // Maybe rename `Templates` as `TemplateKind`, and refactor `Template` so the template doesn't have to be created this way.
+      try template.template.createProject(
+        at: projectPath,
+        inSubdirectory: name != nil,
+        on: localFileSystem,
+        terminal: terminal
+      )
+    } catch let nsError as NSError {
+        throw ProjectInitialisationError.cannotCreateWithTemplate(template, reason: nsError.localizedDescription)
+    } catch let error {
+        throw ProjectInitialisationError.cannotCreateWithTemplate(template, reason: "\(error)")
+    }
   }
+}
+
+// TODO: Add a diagnostics engine for errors thrown.
+
+enum ProjectInitialisationError: Error, CustomStringConvertible {
+    case cannotFindCurrentDirectory
+    case cannotCreateDirectory(path: RelativePath, reason: String)
+    case cannotCreateWithTemplate(Templates, reason: String)
+    
+    var description: String {
+        switch self {
+        case .cannotFindCurrentDirectory:
+            return "Cannot find the current working directory."
+        case let .cannotCreateDirectory(path, reason):
+            return "Cannot create directory ~/\(path.pathString): \(reason)"
+        case let .cannotCreateWithTemplate(template, reason):
+            return "Cannot create project with template '\(template)': \(reason)"
+        }
+    }
 }

--- a/Sources/CartonKit/Model/Project.swift
+++ b/Sources/CartonKit/Model/Project.swift
@@ -15,13 +15,6 @@
 import TSCBasic
 
 public struct Project {
-  let name: String
   let path: AbsolutePath
-  let inPlace: Bool
-
-  public init(name: String, path: AbsolutePath, inPlace: Bool) {
-    self.name = name
-    self.path = path
-    self.inPlace = inPlace
-  }
+  var name: String { path.basename }
 }

--- a/Sources/CartonKit/Model/Template.swift
+++ b/Sources/CartonKit/Model/Template.swift
@@ -245,7 +245,6 @@ extension Templates {
         """
         .write(to: $0)
       }
-
     }
   }
 }

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -283,21 +283,21 @@ public final class Toolchain {
     return testBundlePath
   }
 
-  public func packageInit(name: String, type: PackageType, inPlace: Bool) throws {
-    var initArgs = [
+  public func runPackageInit(name: String, type: PackageType, initialiseInSubdirectory: Bool) throws {
+    var arguments = [
       swiftPath.pathString, "package", "init",
       "--type", type.rawValue,
     ]
-    if !inPlace {
-      initArgs.append(contentsOf: ["--name", name])
-    }
-    try ProcessRunner(initArgs, terminal)
-      .waitUntilFinished()
+	
+	if initialiseInSubdirectory {
+		arguments += ["--name", name]
+	}
+	
+    try ProcessRunner(arguments, terminal).waitUntilFinished()
   }
 
   public func runPackage(_ arguments: [String]) throws {
-    let args = [swiftPath.pathString, "package"] + arguments
-    try ProcessRunner(args, terminal)
-      .waitUntilFinished()
+    let arguments = [swiftPath.pathString, "package"] + arguments
+    try ProcessRunner(arguments, terminal).waitUntilFinished()
   }
 }


### PR DESCRIPTION
`Project.inPlace` is used only once, when initialising a new package through SwiftPM. And it's somewhat redundant along with `.name` when `.path` is really the only thing needed.

The logic can be simplified even further if/when we use libSwiftPM directly.

This PR contains no functional change, but is API-breaking for any other project that depends on CartonKit or SwiftToolchain.