### PR TITLE
Add `carton init` with template test. Supports #99

### DIFF
--- a/Tests/CartonCommandTests/InitCommandTests.swift
+++ b/Tests/CartonCommandTests/InitCommandTests.swift
@@ -73,4 +73,84 @@ final class InitCommandTests: XCTestCase {
     // finally, clean up
     try packageDirectory.delete()
   }
+
+  func testInitWithTokamakTemplate() throws {
+    // given I've created a directory
+    let package = "fusion"
+    let packageDirectory = testFixturesDirectory.appending(component: package)
+    let expectedTemplateSource =
+      """
+      import TokamakDOM
+
+      struct TokamakApp: App {
+          var body: some Scene {
+              WindowGroup("Tokamak App") {
+                  ContentView()
+              }
+          }
+      }
+
+      struct ContentView: View {
+          var body: some View {
+              Text("Hello, world!")
+          }
+      }
+
+      // @main attribute is not supported in SwiftPM apps.
+      // See https://bugs.swift.org/browse/SR-12683 for more details.
+      TokamakApp.main()
+
+      """
+
+    // it's ok if there is nothing to delete
+    do { try packageDirectory.delete() } catch {}
+
+    try packageDirectory.mkdir()
+
+    XCTAssertTrue(packageDirectory.exists, "Did not create \(package) directory")
+
+    AssertExecuteCommand(
+      command: "carton init --template tokamak",
+      cwd: packageDirectory.url
+    )
+
+    // Confirm that the files are actually in the folder
+    XCTAssertTrue(packageDirectory.ls().contains("Package.swift"), "Package.swift does not exist")
+    XCTAssertTrue(packageDirectory.ls().contains("README.md"), "README.md does not exist")
+    XCTAssertTrue(packageDirectory.ls().contains(".gitignore"), ".gitignore does not exist")
+    XCTAssertTrue(packageDirectory.ls().contains("Sources"), "Sources does not exist")
+    XCTAssertTrue(
+      packageDirectory.ls().contains("Sources/\(package)"),
+      "Sources/\(package) does not exist"
+    )
+    XCTAssertTrue(
+      packageDirectory.ls().contains("Sources/\(package)/main.swift"),
+      "Sources/\(package)/main.swift does not exist"
+    )
+    XCTAssertTrue(packageDirectory.ls().contains("Tests"), "Tests does not exist")
+    XCTAssertTrue(
+      packageDirectory.ls().contains("Tests/LinuxMain.swift"),
+      "Tests/LinuxMain.swift does not exist"
+    )
+    XCTAssertTrue(
+      packageDirectory.ls().contains("Tests/\(package)Tests"),
+      "Tests/\(package)Tests does not exist"
+    )
+    XCTAssertTrue(
+      packageDirectory.ls().contains("Tests/\(package)Tests/\(package)Tests.swift"),
+      "Tests/\(package)Tests/\(package)Tests.swift does not exist"
+    )
+    XCTAssertTrue(
+      packageDirectory.ls().contains("Tests/\(package)Tests/XCTestManifests.swift"),
+      "Tests/\(package)Tests/XCTestManifests.swift does not exist"
+    )
+
+    let actualTemplateSource = try String(contentsOfFile: packageDirectory
+      .appending(components: "Sources", package, "main.swift").pathString)
+
+    XCTAssertEqual(expectedTemplateSource, actualTemplateSource, "Template Sources do not match")
+
+    // finally, clean up
+    try packageDirectory.delete()
+  }
 }

--- a/Tests/CartonCommandTests/InitCommandTests.swift
+++ b/Tests/CartonCommandTests/InitCommandTests.swift
@@ -78,29 +78,6 @@ final class InitCommandTests: XCTestCase {
     // given I've created a directory
     let package = "fusion"
     let packageDirectory = testFixturesDirectory.appending(component: package)
-    let expectedTemplateSource =
-      """
-      import TokamakDOM
-
-      struct TokamakApp: App {
-          var body: some Scene {
-              WindowGroup("Tokamak App") {
-                  ContentView()
-              }
-          }
-      }
-
-      struct ContentView: View {
-          var body: some View {
-              Text("Hello, world!")
-          }
-      }
-
-      // @main attribute is not supported in SwiftPM apps.
-      // See https://bugs.swift.org/browse/SR-12683 for more details.
-      TokamakApp.main()
-
-      """
 
     // it's ok if there is nothing to delete
     do { try packageDirectory.delete() } catch {}
@@ -153,4 +130,28 @@ final class InitCommandTests: XCTestCase {
     // finally, clean up
     try packageDirectory.delete()
   }
+
+  let expectedTemplateSource =
+    """
+    import TokamakDOM
+
+    struct TokamakApp: App {
+        var body: some Scene {
+            WindowGroup("Tokamak App") {
+                ContentView()
+            }
+        }
+    }
+
+    struct ContentView: View {
+        var body: some View {
+            Text("Hello, world!")
+        }
+    }
+
+    // @main attribute is not supported in SwiftPM apps.
+    // See https://bugs.swift.org/browse/SR-12683 for more details.
+    TokamakApp.main()
+
+    """
 }


### PR DESCRIPTION
Pretty straight forward test. I am considering removing the full source comparison and only looking for "import TokamakDOM" and then including a lookup in the Package.swift file for the "tokamak repository"