### PR TITLE
Bring wasm-strip back into the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
   libsqlite3-0 \
   libsqlite3-dev \
   curl unzip \
+  wabt binaryen \
   && export WASMER_DIR=/usr/local && curl https://get.wasmer.io -sSfL | sh && \
   rm -r /var/lib/apt/lists/*
 
@@ -23,7 +24,6 @@ RUN mkdir -p $CARTON_ROOT/sdk && \
 COPY . carton/
 
 RUN cd carton && \
-  ./install_ubuntu_deps.sh && \
   swift build -c release --build-tests --enable-test-discovery && \
   mv .build/release/carton /usr/bin && \
   cd .. && \

--- a/install_ubuntu_deps.sh
+++ b/install_ubuntu_deps.sh
@@ -1,7 +1,0 @@
-#/bin/bash
-
-set -ex
-
-curl -L -v -o binaryen.tar.gz https://github.com/WebAssembly/binaryen/releases/download/version_97/binaryen-version_97-x86_64-linux.tar.gz
-tar xzvf binaryen.tar.gz
-cp binaryen-version_97/bin/* /usr/local/bin


### PR DESCRIPTION
It looks like the carton image (and hence the swift-action one, which is derived from it), doesn't have the `wasm-strip` binary anymore.

This PR brings back the binary into the image. While doing that, it also installs the different WebAssembly tools from Ubuntu repositories.