### PR TITLE
WIP: Fix environment detection from User-Agent header

### DIFF
--- a/Sources/CartonKit/Server/Application.swift
+++ b/Sources/CartonKit/Server/Application.swift
@@ -50,7 +50,7 @@ extension Application {
     }
 
     webSocket("watcher") { request, ws in
-      let environment = request.headers["User-Agent"].compactMap(DestinationEnvironment.init).first
+      let environment = request.headers["User-Agent"].compactMap(DestinationEnvironment.from).first
         ?? .other
 
       configuration.onWebSocketOpen(ws, environment)

--- a/Sources/CartonKit/Server/Environment+UserAgent.swift
+++ b/Sources/CartonKit/Server/Environment+UserAgent.swift
@@ -15,20 +15,20 @@
 import SwiftToolchain
 
 extension DestinationEnvironment {
-  init?(userAgent: String) {
+  static func from(userAgent: String) -> DestinationEnvironment? {
     if userAgent.contains("Firefox") {
-      self = .firefox
+      return .firefox
     }
     // Edge UA string contains `Chrome` and `Safari` so this must go first
     if userAgent.contains("Edg/") {
-      self = .edge
+      return .edge
     }
     // Chrome UA string contains `Safari` so this must go first
     if userAgent.contains("Chrome/") {
-      self = .chrome
+      return .chrome
     }
     if userAgent.contains("Safari/") {
-      self = .safari
+      return .safari
     }
 
     return nil


### PR DESCRIPTION
The `DestinationEnvironment` was not correctly detected from the `User-Agent` header of a WebSocket connection, always resulted in `.other`. This disabled any stack trace demangling.

Fixes #248.