### PR TITLE
Bump version to 0.11.0, update dependencies

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,12 +17,9 @@ jobs:
           - os: macos-10.15
             swift_version: 5.3
             xcode: /Applications/Xcode_12.app/Contents/Developer
-          # - os: macos-11.0
-          #   swift_version: 5.2
-          #   xcode: /Applications/Xcode_11.7.app/Contents/Developer
-          # - os: macos-11.0
-          #   swift_version: 5.3
-          #   xcode: /Applications/Xcode_12.2.app/Contents/Developer
+          - os: macos-11
+            swift_version: 5.4
+            xcode: /Applications/Xcode_12.5.app/Contents/Developer
           - os: ubuntu-18.04
             swift_version: 5.4
           - os: ubuntu-20.04

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,6 +20,9 @@ jobs:
           - os: macos-11
             swift_version: 5.4
             xcode: /Applications/Xcode_12.5.app/Contents/Developer
+          - os: macos-11
+            swift_version: 5.5
+            xcode: /Applications/Xcode_13.0.app/Contents/Developer
           - os: ubuntu-18.04
             swift_version: 5.4
           - os: ubuntu-20.04

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,9 +20,9 @@ jobs:
           - os: macos-11
             swift_version: 5.4
             xcode: /Applications/Xcode_12.5.app/Contents/Developer
-          - os: macos-11
-            swift_version: 5.5
-            xcode: /Applications/Xcode_13.0.app/Contents/Developer
+#           - os: macos-11
+#             swift_version: 5.5
+#             xcode: /Applications/Xcode_13.0.app/Contents/Developer
           - os: ubuntu-18.04
             swift_version: 5.4
           - os: ubuntu-20.04

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
       url: "https://github.com/apple/swift-tools-support-core.git",
       .branch("release/5.4")
     ),
-    .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.10.0"),
+    .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.12.0"),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.29.3"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "1.1.0"),
     .package(url: "https://github.com/JohnSundell/Splash.git", from: "0.14.0"),

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.3.1-RELEASE"
+public let defaultToolchainVersion = "wasm-5.4.0-RELEASE"

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.4.0-RELEASE"
+public let defaultToolchainVersion = "wasm-5.4-SNAPSHOT-2021-08-26-a"

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.4-SNAPSHOT-2021-08-26-a"
+public let defaultToolchainVersion = "wasm-5.4-SNAPSHOT-2021-08-30-a"

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.4.0-RELEASE"
+public let defaultToolchainVersion = "wasm-5.4-SNAPSHOT-2021-08-30-a"

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.4-SNAPSHOT-2021-08-30-a"
+public let defaultToolchainVersion = "wasm-5.4.0-RELEASE"

--- a/Sources/CartonHelpers/Version.swift
+++ b/Sources/CartonHelpers/Version.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let cartonVersion = "0.10.0"
+public let cartonVersion = "0.11.0"

--- a/Sources/CartonKit/Model/Template.swift
+++ b/Sources/CartonKit/Model/Template.swift
@@ -179,7 +179,7 @@ extension Templates {
           .init(
             name: "Tokamak",
             url: "https://github.com/TokamakUI/Tokamak",
-            version: .from("0.7.0")
+            version: .from("0.8.0")
           ),
         ],
         targetDepencencies: [

--- a/Tests/CartonCommandTests/BundleCommandTests.swift
+++ b/Tests/CartonCommandTests/BundleCommandTests.swift
@@ -37,7 +37,8 @@ final class BundleCommandTests: XCTestCase {
 
     AssertExecuteCommand(
       command: "carton bundle",
-      cwd: packageDirectory.url
+      cwd: packageDirectory.url,
+      debug: true
     )
 
     // Confirm that the files are actually in the folder

--- a/Tests/CartonCommandTests/CommandTestHelper.swift
+++ b/Tests/CartonCommandTests/CommandTestHelper.swift
@@ -233,7 +233,7 @@ public extension XCTest {
     let output = Pipe()
     process.standardOutput = shouldPrintOutput ? FileHandle.standardOutput : output
     let error = Pipe()
-    process.standardError = shouldPrintOutput ? FileHandle.standardOutput : error
+    process.standardError = shouldPrintOutput ? FileHandle.standardError : error
 
     if #available(macOS 10.13, *) {
       guard (try? process.run()) != nil else {

--- a/Tests/CartonCommandTests/CommandTestHelper.swift
+++ b/Tests/CartonCommandTests/CommandTestHelper.swift
@@ -233,7 +233,7 @@ public extension XCTest {
     let output = Pipe()
     process.standardOutput = shouldPrintOutput ? FileHandle.standardOutput : output
     let error = Pipe()
-    process.standardError = shouldPrintOutput ? FileHandle.standardError : error
+    process.standardError = shouldPrintOutput ? FileHandle.standardOutput : error
 
     if #available(macOS 10.13, *) {
       guard (try? process.run()) != nil else {

--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -45,6 +45,7 @@ final class DevCommandTests: XCTestCase {
 
     guard let process = executeCommand(
       command: "carton dev --verbose",
+      shouldPrintOutput: true,
       cwd: packageDirectory.url
     ) else {
       XCTFail("Could not create process")

--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -73,6 +73,7 @@ final class DevCommandTests: XCTestCase {
 
     guard let process = executeCommand(
       command: "carton dev --verbose --port 8081 --host 0.0.0.0",
+      shouldPrintOutput: true,
       cwd: packageDirectory.url
     ) else {
       XCTFail("Could not create process")

--- a/Tests/CartonCommandTests/InitCommandTests.swift
+++ b/Tests/CartonCommandTests/InitCommandTests.swift
@@ -54,10 +54,6 @@ final class InitCommandTests: XCTestCase {
     )
     XCTAssertTrue(packageDirectory.ls().contains("Tests"), "Tests does not exist")
     XCTAssertTrue(
-      packageDirectory.ls().contains("Tests/LinuxMain.swift"),
-      "Tests/LinuxMain.swift does not exist"
-    )
-    XCTAssertTrue(
       packageDirectory.ls().contains("Tests/\(package)Tests"),
       "Tests/\(package)Tests does not exist"
     )
@@ -105,10 +101,6 @@ final class InitCommandTests: XCTestCase {
       "Sources/\(package)/main.swift does not exist"
     )
     XCTAssertTrue(packageDirectory.ls().contains("Tests"), "Tests does not exist")
-    XCTAssertTrue(
-      packageDirectory.ls().contains("Tests/LinuxMain.swift"),
-      "Tests/LinuxMain.swift does not exist"
-    )
     XCTAssertTrue(
       packageDirectory.ls().contains("Tests/\(package)Tests"),
       "Tests/\(package)Tests does not exist"

--- a/Tests/CartonCommandTests/InitCommandTests.swift
+++ b/Tests/CartonCommandTests/InitCommandTests.swift
@@ -61,10 +61,6 @@ final class InitCommandTests: XCTestCase {
       packageDirectory.ls().contains("Tests/\(package)Tests/\(package)Tests.swift"),
       "Tests/\(package)Tests/\(package)Tests.swift does not exist"
     )
-    XCTAssertTrue(
-      packageDirectory.ls().contains("Tests/\(package)Tests/XCTestManifests.swift"),
-      "Tests/\(package)Tests/XCTestManifests.swift does not exist"
-    )
 
     // finally, clean up
     try packageDirectory.delete()
@@ -108,10 +104,6 @@ final class InitCommandTests: XCTestCase {
     XCTAssertTrue(
       packageDirectory.ls().contains("Tests/\(package)Tests/\(package)Tests.swift"),
       "Tests/\(package)Tests/\(package)Tests.swift does not exist"
-    )
-    XCTAssertTrue(
-      packageDirectory.ls().contains("Tests/\(package)Tests/XCTestManifests.swift"),
-      "Tests/\(package)Tests/XCTestManifests.swift does not exist"
     )
 
     let actualTemplateSource = try String(contentsOfFile: packageDirectory

--- a/Tests/CartonCommandTests/SDKCommandTests.swift
+++ b/Tests/CartonCommandTests/SDKCommandTests.swift
@@ -72,14 +72,14 @@ final class SDKCommandTests: XCTestCase {
     // it's ok if there is nothing to delete
     do { try swiftVersion.delete() } catch {}
 
-    let alternateLocal = "wasm-5.3.1"
+    let alternateLocal = "wasm-5.4.0"
 
     try alternateLocal.write(to: swiftVersion.url, atomically: true, encoding: .utf8)
 
     AssertExecuteCommand(
       command: "carton sdk local",
       cwd: packageDirectory.url,
-      expected: "wasm-5.3.1",
+      expected: "wasm-5.4.0",
       expectedContains: true
     )
 

--- a/Tests/Fixtures/Milk/Package.resolved
+++ b/Tests/Fixtures/Milk/Package.resolved
@@ -6,17 +6,17 @@
         "repositoryURL": "https://github.com/swiftwasm/JavaScriptKit.git",
         "state": {
           "branch": null,
-          "revision": "b7a02434c6e973c08c3fd5069105ef44dd82b891",
-          "version": "0.9.0"
+          "revision": "b19e7c8b10a2750ed47753e31ed13613171f3294",
+          "version": "0.10.1"
         }
       },
       {
         "package": "OpenCombine",
-        "repositoryURL": "https://github.com/TokamakUI/OpenCombine.git",
+        "repositoryURL": "https://github.com/OpenCombine/OpenCombine.git",
         "state": {
           "branch": null,
-          "revision": "bccff3e7c84bc559e1aa0aa9ca878400360d439d",
-          "version": "0.12.0-alpha2"
+          "revision": "28993ae57de5a4ea7e164787636cafad442d568c",
+          "version": "0.12.0"
         }
       },
       {
@@ -24,17 +24,26 @@
         "repositoryURL": "https://github.com/swiftwasm/OpenCombineJS.git",
         "state": {
           "branch": null,
-          "revision": "b346f955ed21ab44576e204a7554210c77f69b9b",
-          "version": "0.0.1"
+          "revision": "eaf324ce78710f53b52fb82e9a8de4693633e33a",
+          "version": "0.1.1"
         }
       },
       {
-        "package": "Runtime",
-        "repositoryURL": "https://github.com/MaxDesiatov/Runtime.git",
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "a617ead8a125a97e69d6100e4d27922006e82e0a",
-          "version": "2.1.2"
+          "revision": "83b23d940471b313427da226196661856f6ba3e0",
+          "version": "0.4.4"
+        }
+      },
+      {
+        "package": "Benchmark",
+        "repositoryURL": "https://github.com/google/swift-benchmark",
+        "state": {
+          "branch": null,
+          "revision": "8e0ef8bb7482ab97dcd2cd1d6855bd38921c345d",
+          "version": "0.1.0"
         }
       },
       {
@@ -42,8 +51,8 @@
         "repositoryURL": "https://github.com/TokamakUI/Tokamak",
         "state": {
           "branch": null,
-          "revision": "b4b0efca4de0ce9cff771649dfbcd13c5736e7f0",
-          "version": "0.6.1"
+          "revision": "c2ed28ca40445b1b63bfdfe45de2507e5eb24a21",
+          "version": "0.8.0"
         }
       }
     ]

--- a/Tests/Fixtures/Milk/Package.swift
+++ b/Tests/Fixtures/Milk/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     .executable(name: "Milk", targets: ["Milk"]),
   ],
   dependencies: [
-    .package(name: "Tokamak", url: "https://github.com/TokamakUI/Tokamak", from: "0.6.1"),
+    .package(name: "Tokamak", url: "https://github.com/TokamakUI/Tokamak", from: "0.8.0"),
   ],
   targets: [
     .target(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "carton",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@wasmer/wasi": "^0.12.0",
         "@wasmer/wasmfs": "^0.12.0",
-        "javascript-kit-swift": "^0.9.0",
+        "javascript-kit-swift": "^0.10.1",
         "npm-run-all": "^4.1.5",
         "reconnecting-websocket": "^4.4.0",
-        "webpack": "^4.44.1",
+        "webpack": "^4.46.0",
         "webpack-cli": "^3.3.12"
       }
     },
@@ -2725,10 +2725,11 @@
       }
     },
     "node_modules/javascript-kit-swift": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/javascript-kit-swift/-/javascript-kit-swift-0.9.0.tgz",
-      "integrity": "sha512-yJ5xh9fK/CCfVQ4oKvgWV3x8DSeixtOMru4G9VvZlfATndChCa8ulFKVH2oEkloIfLW6mdszP4vI7WASjXig3g==",
-      "dev": true
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/javascript-kit-swift/-/javascript-kit-swift-0.10.1.tgz",
+      "integrity": "sha512-zGBl04b499wZdW9U6kWPOC3DYfl32z9my7QXUzrCem+akUpTFpe6KCCtANCSuCtqpcSAaK5YDWPOHuQDa0zg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -3578,9 +3579,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -7839,9 +7840,9 @@
       "dev": true
     },
     "javascript-kit-swift": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/javascript-kit-swift/-/javascript-kit-swift-0.9.0.tgz",
-      "integrity": "sha512-yJ5xh9fK/CCfVQ4oKvgWV3x8DSeixtOMru4G9VvZlfATndChCa8ulFKVH2oEkloIfLW6mdszP4vI7WASjXig3g==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/javascript-kit-swift/-/javascript-kit-swift-0.10.1.tgz",
+      "integrity": "sha512-zGBl04b499wZdW9U6kWPOC3DYfl32z9my7QXUzrCem+akUpTFpe6KCCtANCSuCtqpcSAaK5YDWPOHuQDa0zg/Q==",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -8569,9 +8570,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carton",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "📦 Watcher, bundler, and test runner for your SwiftWasm apps ",
   "main": "index.js",
   "scripts": {
@@ -28,10 +28,10 @@
   "devDependencies": {
     "@wasmer/wasi": "^0.12.0",
     "@wasmer/wasmfs": "^0.12.0",
-    "javascript-kit-swift": "^0.9.0",
+    "javascript-kit-swift": "^0.10.1",
     "npm-run-all": "^4.1.5",
     "reconnecting-websocket": "^4.4.0",
-    "webpack": "^4.44.1",
+    "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   }
 }


### PR DESCRIPTION
In this version we start using SwiftWasm 5.4.0 and Tokamak 0.8 by default. Other related dependencies have been updated.