### PR TITLE
Upgrade to SwiftPM 5.5 for parsing manifests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
-          "version": "0.3.2"
+          "revision": "83b23d940471b313427da226196661856f6ba3e0",
+          "version": "0.4.4"
         }
       },
       {
@@ -95,8 +95,8 @@
         "package": "swift-driver",
         "repositoryURL": "https://github.com/apple/swift-driver.git",
         "state": {
-          "branch": "release/5.4",
-          "revision": "93e8b927225a62b963ebe13ab11e04192fa8a67b",
+          "branch": "release/5.5",
+          "revision": "86c54dacd270e0c43374c0cb9b2ceb2924c9ea72",
           "version": null
         }
       },
@@ -104,8 +104,8 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "release/5.4",
-          "revision": "eb56a00ed9dfd62c2ce4ec86183ff0bc0afda997",
+          "branch": "release/5.5",
+          "revision": "83c4bcb8dfca48cc065325287b55d08ff7b26428",
           "version": null
         }
       },
@@ -176,8 +176,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "release/5.4",
-          "revision": "374cdb42d7b146837de70489a04c5df956092685",
+          "branch": "release/5.5",
+          "revision": "7a1f113534689c77b3a4110288478580b7b8d91c",
           "version": null
         }
       },
@@ -185,8 +185,8 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "release/5.4",
-          "revision": "d7bd4375c26e7dab2c17791cfa06f9b981d02339",
+          "branch": "release/5.5",
+          "revision": "3b586ce12865db205081acdcea79fe5509b28152",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -24,16 +24,16 @@ let package = Package(
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.2.2"),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
-      .upToNextMinor(from: "0.3.0")
+      .upToNextMinor(from: "0.4.0")
     ),
     .package(
       name: "SwiftPM",
       url: "https://github.com/apple/swift-package-manager.git",
-      .branch("release/5.4")
+      .branch("release/5.5")
     ),
     .package(
       url: "https://github.com/apple/swift-tools-support-core.git",
-      .branch("release/5.4")
+      .branch("release/5.5")
     ),
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.12.0"),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.29.3"),

--- a/Sources/SwiftToolchain/Manifest.swift
+++ b/Sources/SwiftToolchain/Manifest.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Carton contributors
+// Copyright 2021 Carton contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,34 +48,6 @@ public enum PackageType: String {
 
 // MARK: Custom Decodable Wrappers
 
-// TODO: Remove this struct when we move to `Swift 5.4`
-/// A temprary wrapper for decoding `PackageDependencyDescription` since
-/// `productFilter` is not available in dumped JSON with pre-5.4 compilers.
-struct DumpedPackageDependencyDescription: Decodable {
-  var dependendy: PackageDependencyDescription
-
-  private enum CodingKeys: CodingKey {
-    case name, url, requirement, productFilter
-  }
-
-  init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    let name = try container.decode(String.self, forKey: .name)
-    let url = try container.decode(String.self, forKey: .url)
-    let requirement = try container.decode(
-      PackageDependencyDescription.Requirement.self,
-      forKey: .requirement
-    )
-    let productFilter = try? container.decode(ProductFilter.self, forKey: .productFilter)
-    dependendy = PackageDependencyDescription(
-      name: name,
-      url: url,
-      requirement: requirement,
-      productFilter: productFilter ?? .nothing
-    )
-  }
-}
-
 /// A wrapper around `Manifest` needed for decoding from `dump-package` output,
 /// since when encoding several (required for initialization) keys are skipped.
 /// When decoding this wrapper, callers must provide an `unencodedKey` in the
@@ -94,9 +66,9 @@ struct DumpedManifest: Decodable {
 
   private enum CodingKeys: CodingKey {
     case name, toolsVersion,
-         pkgConfig, providers, cLanguageStandard, cxxLanguageStandard, swiftLanguageVersions,
-         dependencies, products, targets, platforms, packageKind, revision,
-         defaultLocalization
+      pkgConfig, providers, cLanguageStandard, cxxLanguageStandard, swiftLanguageVersions,
+      dependencies, products, targets, platforms, packageKind, revision,
+      defaultLocalization
   }
 
   init(from decoder: Decoder) throws {
@@ -122,31 +94,30 @@ struct DumpedManifest: Decodable {
       [SwiftLanguageVersion]?.self,
       forKey: .swiftLanguageVersions
     )
-    // TODO: Change to `PackageDependencyDescription` when we move to `Swift 5.4`
     let dependencies = try container.decode(
-      [DumpedPackageDependencyDescription].self,
+      [PackageDependencyDescription].self,
       forKey: .dependencies
     )
     let products = try container.decode([ProductDescription].self, forKey: .products)
     let targets = try container.decode([TargetDescription].self, forKey: .targets)
     let platforms = try container.decode([PlatformDescription].self, forKey: .platforms)
-    // TODO: Change to non-optional when we move to `Swift 5.4`
-    // `packageKind` is not available in dumped JSON with pre-5.4 compilers.
-    let packageKind = try? container.decode(PackageReference.Kind.self, forKey: .packageKind)
+    let packageKind = try container.decode(PackageReference.Kind.self, forKey: .packageKind)
     manifest = Manifest(
       name: name,
-      platforms: platforms,
       path: unencoded.path,
-      url: unencoded.url,
+      packageKind: packageKind,
+      packageLocation: unencoded.url,
+      defaultLocalization: nil, // not encoded in JSON
+      platforms: platforms,
       version: unencoded.version,
+      revision: nil, // not encoded in JSON
       toolsVersion: toolsVersion,
-      packageKind: packageKind ?? .root,
       pkgConfig: pkgConfig,
       providers: providers,
       cLanguageStandard: cLanguageStandard,
       cxxLanguageStandard: cxxLanguageStandard,
       swiftLanguageVersions: swiftLanguageVersions,
-      dependencies: dependencies.map(\.dependendy),
+      dependencies: dependencies,
       products: products,
       targets: targets
     )


### PR DESCRIPTION
This is part of fixing issues like https://github.com/OpenCombine/OpenCombine/issues/225 of running under Monterey with Xcode 13.

Problem is I think it won't play nice with compilers < 5.5, which means we'll be tying the version of Carton to latest toolchain going forward.