### PR TITLE
Use SwiftWasm 5.5.0, bump version to 0.12.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "0ed00b8b36b1bc445e141d9227e5b7da2ac6a237",
-          "version": "1.8.0"
+          "revision": "170fd536f931c0bffb58f37a53fc238e77f42258",
+          "version": "1.6.4"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "ec2e080d7011a81bd67f10bf41efe6104d7799d6",
-          "version": "1.7.0"
+          "revision": "0ed00b8b36b1bc445e141d9227e5b7da2ac6a237",
+          "version": "1.8.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "1081b0b0541f535ca088acdb56f5ca5598bc6247",
-          "version": "1.6.3"
+          "revision": "ec2e080d7011a81bd67f10bf41efe6104d7799d6",
+          "version": "1.7.0"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "6aa9347d9bc5bbfe6a84983aec955c17ffea96ef",
-          "version": "2.33.0"
+          "revision": "addf69cfe60376c325397c8926589415576b1dd1",
+          "version": "2.34.0"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "27119271502bf266be293be5325f0fb72435e8fd",
-          "version": "4.49.2"
+          "revision": "6a5a3b5244d39e2614382c77ddf62e63b712ad06",
+          "version": "4.53.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     .executable(name: "carton-release", targets: ["carton-release"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.7.0"),
+    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.8.0"),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
       from: "0.4.3"

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,10 @@ let package = Package(
     .executable(name: "carton-release", targets: ["carton-release"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.8.0"),
+    .package(
+      url: "https://github.com/swift-server/async-http-client.git",
+      .upToNextMinor(from: "1.6.4")
+    ),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
       from: "0.4.3"

--- a/Package.swift
+++ b/Package.swift
@@ -21,12 +21,12 @@ let package = Package(
     .executable(name: "carton-release", targets: ["carton-release"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.6.3"),
+    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.7.0"),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
       from: "0.4.3"
     ),
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.34.0"),
     .package(
       name: "SwiftPM",
       url: "https://github.com/apple/swift-package-manager.git",
@@ -37,7 +37,7 @@ let package = Package(
       .branch("release/5.5")
     ),
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.12.0"),
-    .package(url: "https://github.com/vapor/vapor.git", from: "4.49.2"),
+    .package(url: "https://github.com/vapor/vapor.git", from: "4.53.0"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "1.1.0"),
     .package(url: "https://github.com/JohnSundell/Splash.git", from: "0.16.0"),
     .package(

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.5-SNAPSHOT-2021-11-16-a"
+public let defaultToolchainVersion = "wasm-5.5.0-RELEASE"

--- a/Sources/CartonHelpers/Version.swift
+++ b/Sources/CartonHelpers/Version.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let cartonVersion = "0.11.0"
+public let cartonVersion = "0.12.0"

--- a/Sources/SwiftToolchain/ToolchainInstallation.swift
+++ b/Sources/SwiftToolchain/ToolchainInstallation.swift
@@ -52,7 +52,11 @@ extension ToolchainSystem {
     // Clean up the downloaded file (especially important for failed downloads, otherwise running
     // `carton` again will fail trying to pick up the broken download).
     defer {
-      try fileSystem.removeFileTree(archivePath)
+      do {
+        try fileSystem.removeFileTree(archivePath)
+      } catch {
+        terminal.write("Failed to remove downloaded file with error \(error)\n", inColor: .red)
+      }
     }
 
     _ = try tsc_await { (completion: @escaping (Result<(), Error>) -> ()) in

--- a/Sources/SwiftToolchain/ToolchainInstallation.swift
+++ b/Sources/SwiftToolchain/ToolchainInstallation.swift
@@ -50,8 +50,13 @@ extension ToolchainSystem {
     let request = try HTTPClient.Request.get(url: url)
 
     _ = try tsc_await { (completion: @escaping (Result<(), Error>) -> ()) in
-      client.execute(request: request, delegate: delegate).futureResult.whenComplete { _ in
-        subject.send(completion: .finished)
+      client.execute(request: request, delegate: delegate).futureResult.whenComplete {
+        switch $0 {
+        case .success:
+          subject.send(completion: .finished)
+        case let .failure(error):
+          subject.send(completion: .failure(error))
+        }
       }
 
       subject

--- a/Tests/Fixtures/TestApp/Package.resolved
+++ b/Tests/Fixtures/TestApp/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swiftwasm/JavaScriptKit",
         "state": {
           "branch": null,
-          "revision": "b19e7c8b10a2750ed47753e31ed13613171f3294",
-          "version": "0.10.1"
+          "revision": "309e63c03d8116210ad0437f5d1f09a26d4de48b",
+          "version": "0.11.1"
         }
       }
     ]

--- a/Tests/Fixtures/TestApp/Package.swift
+++ b/Tests/Fixtures/TestApp/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .executable(name: "TestApp", targets: ["TestApp"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/swiftwasm/JavaScriptKit", from: "0.10.1"),
+    .package(url: "https://github.com/swiftwasm/JavaScriptKit", from: "0.11.1"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carton",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "carton",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@wasmer/wasi": "^0.12.0",
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.906",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.906.tgz",
-      "integrity": "sha512-UjoECdcOYIVzWmrbtNnYpPrDuu+RtiO5W08Vdbid9ydGQMSdnqtJUtvOqQEAVQqpoXN9kSW9YnQufvzLQMYQOw==",
+      "version": "1.3.904",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.904.tgz",
+      "integrity": "sha512-x5uZWXcVNYkTh4JubD7KSC1VMKz0vZwJUqVwY3ihsW0bst1BXDe494Uqbg3Y0fDGVjJqA8vEeGuvO5foyH2+qw==",
       "dev": true
     },
     "node_modules/end-of-stream": {
@@ -2754,9 +2754,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.906",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.906.tgz",
-      "integrity": "sha512-UjoECdcOYIVzWmrbtNnYpPrDuu+RtiO5W08Vdbid9ydGQMSdnqtJUtvOqQEAVQqpoXN9kSW9YnQufvzLQMYQOw==",
+      "version": "1.3.904",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.904.tgz",
+      "integrity": "sha512-x5uZWXcVNYkTh4JubD7KSC1VMKz0vZwJUqVwY3ihsW0bst1BXDe494Uqbg3Y0fDGVjJqA8vEeGuvO5foyH2+qw==",
       "dev": true
     },
     "end-of-stream": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carton",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "📦 Watcher, bundler, and test runner for your SwiftWasm apps ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`async-http-client` package is now pinned to 1.6.4, as 1.7.0 and later versions caused issues with toolchain downloads (see https://github.com/swift-server/async-http-client/issues/488 for more details).

I've also updated toolchain downloader code to bubble up download errors, which previously were hidden and made it very hard to diagnose these issues.