### PR TITLE
Bump SwiftWasm to 5.5 in `Dockerfile`, bump AHC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/swiftwasm/swift:5.4-focal
+FROM ghcr.io/swiftwasm/swift:5.5-focal
 
 LABEL maintainer="SwiftWasm Maintainers <hello@swiftwasm.org>"
 LABEL Description="Carton is a watcher, bundler, and test runner for your SwiftWasm apps"
@@ -14,7 +14,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
   rm -r /var/lib/apt/lists/*
 
 ENV CARTON_ROOT=/root/.carton
-ENV CARTON_DEFAULT_TOOLCHAIN=wasm-5.4.0-RELEASE
+ENV CARTON_DEFAULT_TOOLCHAIN=wasm-5.5.0-RELEASE
 
 RUN mkdir -p $CARTON_ROOT/sdk && \
   mkdir -p $CARTON_ROOT/sdk/$CARTON_DEFAULT_TOOLCHAIN && \

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "170fd536f931c0bffb58f37a53fc238e77f42258",
-          "version": "1.6.4"
+          "revision": "70826d038d5bdc3142a386b735792d87ef7a5dfc",
+          "version": "1.8.1"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "b5919e4621973625621980a0408b2a4522b5e67f",
-          "version": "1.18.5"
+          "revision": "39ed0e753596afadad920e302ae769b28f3a982b",
+          "version": "1.19.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/swift-server/async-http-client.git",
-      .upToNextMinor(from: "1.6.4")
+      from: "1.8.1"
     ),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",


### PR DESCRIPTION
Our `Dockerfile` should be updated to depend on SwiftWasm 5.5.

Additionally, Async HTTP Client has fixed the toolchain downloads issue in 1.8.1, I'm setting it as a minimum version in `Package.swift` here.