### PR TITLE
Build `main` Docker images on every push to `main` branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Build nightly Docker image
+name: Build main Docker image
 
 on:
   push:
@@ -26,4 +26,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:nightly
+            ghcr.io/${{ github.repository }}:main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,29 @@
+name: Build nightly Docker image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  docker:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PAT }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:nightly

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -75,3 +75,27 @@ jobs:
         run: docker build . -t gchr.io/swiftwasm/swiftwasm-action:latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+  docker:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PAT }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/swiftwasm/carton:0.12.1
+            ghcr.io/swiftwasm/carton:latest

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -78,18 +78,18 @@ jobs:
           
   docker:
     name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PAT }}
 
       - name: Push Docker image
         uses: docker/build-push-action@v2
@@ -98,3 +98,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:0.12.1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -88,8 +88,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -97,5 +97,5 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/swiftwasm/carton:0.12.1
-            ghcr.io/swiftwasm/carton:latest
+            ghcr.io/${{ github.repository }}:0.12.1
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -75,27 +75,3 @@ jobs:
         run: docker build . -t gchr.io/swiftwasm/swiftwasm-action:latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-  docker:
-    name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.PAT }}
-
-      - name: Push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          file: ./Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:0.12.1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -97,5 +97,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:0.12.1
             ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
This makes it possible to test latest `carton` Docker builds from the `main` branch.