### PR TITLE
Statically link with `SwiftPMDataModel` library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN cd carton && \
   ./install_ubuntu_deps.sh && \
   swift build -c release && \
   mv .build/release/carton /usr/bin && \
-  mv .build/**/libSwiftPMDataModel.so /lib/*-linux-gnu/ && \
   cd .. && \
   rm -rf carton /tmp/wasmer*
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -177,7 +177,7 @@
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
           "branch": "release/5.5",
-          "revision": "7a1f113534689c77b3a4110288478580b7b8d91c",
+          "revision": "1cf38af7ffad738de435ffdbc499c3e9f07a605c",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -33,11 +33,11 @@ let package = Package(
     .package(
       name: "SwiftPM",
       url: "https://github.com/apple/swift-package-manager.git",
-      .branch("release/5.5")
+      .branch("release/5.6")
     ),
     .package(
       url: "https://github.com/apple/swift-tools-support-core.git",
-      .branch("release/5.5")
+      .branch("release/5.6")
     ),
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.12.0"),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.53.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
-      from: "0.4.3"
+      from: "1.0.2"
     ),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.34.0"),
     .package(

--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,7 @@ let package = Package(
       dependencies: [
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "NIOFoundationCompat", package: "swift-nio"),
-        .product(name: "SwiftPMDataModel", package: "SwiftPM"),
+        .product(name: "SwiftPMDataModel-auto", package: "SwiftPM"),
         "CartonHelpers",
         openCombineProduct,
         "WasmTransformer",

--- a/Package.swift
+++ b/Package.swift
@@ -27,17 +27,17 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
-      from: "1.0.2"
+      from: "0.4.3"
     ),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.34.0"),
     .package(
       name: "SwiftPM",
       url: "https://github.com/apple/swift-package-manager.git",
-      .branch("release/5.6")
+      .branch("release/5.5")
     ),
     .package(
       url: "https://github.com/apple/swift-tools-support-core.git",
-      .branch("release/5.6")
+      .branch("release/5.5")
     ),
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.12.0"),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.53.0"),


### PR DESCRIPTION
Resolves #274.

On macOS release binary grows from 27MB to 40MB.