### PR TITLE
Fix Wasmer installation issues in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL org.opencontainers.image.source https://github.com/swiftwasm/carton
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
   apt-get -q install -y \
   build-essential \
+  libncurses5 \
   libsqlite3-0 \
   libsqlite3-dev \
   curl unzip \


### PR DESCRIPTION
Currently https://github.com/swiftwasm/carton/pull/273 fails because of `libtinfo.so.5: cannot open shared object file: No such file or directory` error happening during Wasmer installation. This should be resolved by installing `libncurses5` package explicitly in `Dockerfile`.