### PR TITLE
Add libsqlite3-dev dependency

### DIFF
--- a/install_ubuntu_deps.sh
+++ b/install_ubuntu_deps.sh
@@ -3,9 +3,9 @@
 set -ex
 
 if [ -x "$(command -v sudo)" ]; then
-  sudo apt-get install zlib1g-dev
+  sudo apt-get install zlib1g-dev libsqlite3-dev
 else
-  apt-get install zlib1g-dev
+  apt-get install zlib1g-dev libsqlite3-dev
 fi
 
 BINARYEN_VERSION=105


### PR DESCRIPTION
Fixes #287 

Not installed by default on all Ubuntu-based distributions.