### PR TITLE
Fix crash for packages with `executableTarget`

### DIFF
--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -178,7 +178,7 @@ public actor Server {
         Task { try await self.onChange(changes, configuration) }
       }
       try watcher?.start()
-	}
+  }
   }
 
   private func onChange(_ changes: [AbsolutePath], _ configuration: Configuration) async throws {

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -178,7 +178,7 @@ public actor Server {
         Task { try await self.onChange(changes, configuration) }
       }
       try watcher?.start()
-  }
+    }
   }
 
   private func onChange(_ changes: [AbsolutePath], _ configuration: Configuration) async throws {

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -172,11 +172,13 @@ public actor Server {
       return
     }
 
-    watcher = FSWatch(paths: builder.pathsToWatch, latency: 0.1) { [weak self] changes in
-      guard let self = self, !changes.isEmpty else { return }
-      Task { try await self.onChange(changes, configuration) }
-    }
-    try watcher?.start()
+    if !builder.pathsToWatch.isEmpty {
+      watcher = FSWatch(paths: builder.pathsToWatch, latency: 0.1) { [weak self] changes in
+        guard let self = self, !changes.isEmpty else { return }
+        Task { try await self.onChange(changes, configuration) }
+      }
+      try watcher?.start()
+	}
   }
 
   private func onChange(_ changes: [AbsolutePath], _ configuration: Configuration) async throws {

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -183,9 +183,9 @@ public final class Toolchain {
 
       guard let path = target.path else {
         switch target.type {
-        case .regular:
+        case .regular, .executable:
           return RelativePath("Sources").appending(component: target.name).pathString
-        case .test, .system, .executable, .binary, .plugin:
+        case .test, .system, .binary, .plugin:
           return nil
         }
       }


### PR DESCRIPTION
If we run `carton dev` on a package with a Swift 5.4-style `executableTarget`, carton cannot infer the source path and will crash trying to initialize FSWatch with an empty paths array.
```
TSCUtility/FSWatch.swift:46: Precondition failed
```
Fix this issue for executable targets and prevent similar issues with empty arrays.