### PR TITLE
Add macOS 12 and Xcode 13.3 to CI matrix

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,8 +17,6 @@ jobs:
           - os: macos-11
             swift_version: 5.5
             xcode: /Applications/Xcode_13.2.1.app/Contents/Developer
-          - os: ubuntu-18.04
-            swift_version: 5.5
           - os: ubuntu-20.04
             swift_version: 5.5
     name: Build on ${{ matrix.os }} with Swift ${{ matrix.swift_version }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,6 +11,9 @@ jobs:
     strategy:
       matrix:
         include:
+          - os: macos-12
+            swift_version: 5.6
+            xcode: /Applications/Xcode_13.3.app/Contents/Developer
           - os: macos-11
             swift_version: 5.5
             xcode: /Applications/Xcode_13.2.1.app/Contents/Developer

--- a/Tests/CartonCommandTests/CommandTestHelper.swift
+++ b/Tests/CartonCommandTests/CommandTestHelper.swift
@@ -195,7 +195,7 @@ public extension XCTest {
   }
 
   var cartonPath: String {
-    return debugURL.appendingPathComponent("carton").path
+    debugURL.appendingPathComponent("carton").path
   }
 
   /// Execute shell command and return the process the command is running in

--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -60,7 +60,7 @@ final class DevCommandTests: XCTestCase {
   }
 
   func testWithArguments() throws {
-    let url = "http://0.0.0.0:8081"
+    let url = "http://127.0.0.1:8081"
 
     // the directory was built using `carton init --template tokamak`
     let package = "Milk"
@@ -73,7 +73,7 @@ final class DevCommandTests: XCTestCase {
     do { try packageDirectory.appending(component: ".build").delete() } catch {}
 
     guard let process = executeCommand(
-      command: "carton dev --verbose --port 8081 --host 0.0.0.0",
+      command: "carton dev --verbose --port 8081",
       shouldPrintOutput: true,
       cwd: packageDirectory.url
     ) else {


### PR DESCRIPTION
There are issues with binding 0.0.0.0 address on macOS 12, I'm dropping the corresponding argument from tests in f24d39e8f8bf19e39056bdd51fd840600598ebec. Also seeing issues with Ubuntu 18.04, even though all tests seem to be passing. Dropping it as an old version from CI as well.