### PR TITLE
Don't strip custom sections when --debug-info

### DIFF
--- a/Sources/CartonCLI/Commands/Bundle.swift
+++ b/Sources/CartonCLI/Commands/Bundle.swift
@@ -74,13 +74,14 @@ struct Bundle: AsyncParsableCommand {
       newline: true
     )
 
-    try strip(build.mainWasmPath)
-
-    try terminal.logLookup(
-      "After stripping debug info the main binary size is ",
-      localFileSystem.humanReadableFileSize(build.mainWasmPath),
-      newline: true
-    )
+    if !debugInfo {
+      try strip(build.mainWasmPath)
+      try terminal.logLookup(
+        "After stripping debug info the main binary size is ",
+        localFileSystem.humanReadableFileSize(build.mainWasmPath),
+        newline: true
+      )
+    }
 
     let bundleDirectory = AbsolutePath(localFileSystem.currentWorkingDirectory!, "Bundle")
     try localFileSystem.removeFileTree(bundleDirectory)


### PR DESCRIPTION
Since https://github.com/swiftwasm/carton/pull/301, carton started passing `--debuginfo` to wasm-opt, but it still strips all custom sections before it.