### PR TITLE
Describe `--debug-info` and `-Xswiftc` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,19 @@ directory. You can then use a static file hosting (e.g. [GitHub Pages](https://p
 or any other server with support for static files to deploy your application. All resulting bundle
 files except `index.html` are named by their content hashes to enable [cache
 busting](https://www.keycdn.com/support/what-is-cache-busting). As with `carton dev`, a custom
-`index.html` page can be provided through the `--custom-index-page` option.
+`index.html` page can be provided through the `--custom-index-page` option. You can also pass
+`--debug-info` flag to preserve names and DWARF sections in the resulting `.wasm` file, as these
+are stripped in the `release` configuration by default.
 
 The `carton package` command proxies its subcommands to `swift package` invocations on the
 currently-installed toolchain. This may be useful in situations where you'd like to generate an
 Xcode project file for your app with something like `carton package generate-xcodeproj`. It would be
 equivalent to `swift package generate-xcodeproj`, but invoked with the SwiftWasm toolchain instead
 of the toolchain supplied by Xcode.
+
+All commands that delegate to `swift build` and `swiftc` (namely, `dev`, `test`, and `bundle`)
+can be passed `-Xswiftc` arguments, which is equivalent to `-Xswiftc` in `swift build`. All
+`-Xswiftc` arguments are propagated to `swiftc` itself unmodified.
 
 All of these commands and subcommands can be passed a `--help` flag that prints usage info and
 information about all available options.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ or any other server with support for static files to deploy your application. Al
 files except `index.html` are named by their content hashes to enable [cache
 busting](https://www.keycdn.com/support/what-is-cache-busting). As with `carton dev`, a custom
 `index.html` page can be provided through the `--custom-index-page` option. You can also pass
-`--debug-info` flag to preserve names and DWARF sections in the resulting `.wasm` file, as these
+`--debug-info` flag to preserve `names` and DWARF sections in the resulting `.wasm` file, as these
 are stripped in the `release` configuration by default.
 
 The `carton package` command proxies its subcommands to `swift package` invocations on the


### PR DESCRIPTION
New CLI options added in 0.13.0 weren't described in `README.md`, let's fix that. 