### PR TITLE
Fix "No export `_start` found in the module" error in `carton test` 

### DIFF
--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -357,9 +357,9 @@ public final class Toolchain {
       builderArguments.append(contentsOf: ["-Xlinker", "-licuuc", "-Xlinker", "-licui18n"])
     }
 
-    // SwiftWasm 5.6 requires reactor model from updated wasi-libc
+    // SwiftWasm 5.6 requires reactor model from updated wasi-libc when not building as a command
     // see https://github.com/WebAssembly/WASI/issues/13
-    if version.starts(with: "wasm-5.6") {
+    if version.starts(with: "wasm-5.6") && flavor.environment != .other {
       builderArguments.append(contentsOf: [
         "-Xswiftc", "-Xclang-linker", "-Xswiftc", "-mexec-model=reactor",
         "-Xlinker", "--export=main",

--- a/Tests/CartonCommandTests/TestCommandTests.swift
+++ b/Tests/CartonCommandTests/TestCommandTests.swift
@@ -30,24 +30,23 @@ final class TestCommandTests: XCTestCase {
     client = nil
   }
 
-  // FIXME: re-enable when https://github.com/swiftwasm/WasmTransformer/issues/18 is fixed.
-  // func testWithNoArguments() throws {
-  //   // given I've created a directory
-  //   let package = "TestApp"
-  //   let packageDirectory = testFixturesDirectory.appending(components: package)
+  func testWithNoArguments() throws {
+    // given I've created a directory
+    let package = "TestApp"
+    let packageDirectory = testFixturesDirectory.appending(components: package)
 
-  //   XCTAssertTrue(packageDirectory.exists, "The TestApp directory does not exist")
+    XCTAssertTrue(packageDirectory.exists, "The TestApp directory does not exist")
 
-  //   AssertExecuteCommand(
-  //     command: "carton test",
-  //     cwd: packageDirectory.url,
-  //     debug: true
-  //   )
+    AssertExecuteCommand(
+      command: "carton test",
+      cwd: packageDirectory.url,
+      debug: true
+    )
 
-  //   // finally, clean up
-  //   let buildDirectory = packageDirectory.appending(component: ".build")
-  //   do { try buildDirectory.delete() } catch {}
-  // }
+    // finally, clean up
+    let buildDirectory = packageDirectory.appending(component: ".build")
+    do { try buildDirectory.delete() } catch {}
+  }
 
 // This test is prone to hanging on Linux.
 #if os(macOS)


### PR DESCRIPTION
This enables reactor model only when not building as a command, fixes https://github.com/swiftwasm/carton/issues/313
The breakage happened and was silenced in https://github.com/swiftwasm/carton/pull/310