### PR TITLE
Override clock_res_get function from wasmer/wasi-js to fix memory issue

### DIFF
--- a/entrypoint/bundle.js
+++ b/entrypoint/bundle.js
@@ -46,6 +46,24 @@ const wasi = new WASI({
   },
 });
 
+const wrapWASI = (wasiObject) => {
+  // PATCH: @wasmer-js/wasi@0.x forgets to call `refreshMemory` in `clock_res_get`,
+  // which writes its result to memory view. Without the refresh the memory view,
+  // it accesses a detached array buffer if the memory is grown by malloc.
+  // But they wasmer team discarded the 0.x codebase at all and replaced it with
+  // a new implementation written in Rust. The new version 1.x is really unstable
+  // and not production-ready as far as katei investigated in Apr 2022.
+  // So override the broken implementation of `clock_res_get` here instead of
+  // fixing the wasi polyfill.
+  // Reference: https://github.com/wasmerio/wasmer-js/blob/55fa8c17c56348c312a8bd23c69054b1aa633891/packages/wasi/src/index.ts#L557
+  const original_clock_res_get = wasiObject.wasiImport["clock_res_get"];
+  wasiObject.wasiImport["clock_res_get"] = (clockId, resolution) => {
+    wasiObject.refreshMemory();
+    return original_clock_res_get(clockId, resolution)
+  };
+  return wasiObject.wasiImport;
+}
+
 const startWasiTask = async () => {
   // Fetch our Wasm File
   const response = await fetch("REPLACE_THIS_WITH_THE_MAIN_WEBASSEMBLY_MODULE");
@@ -54,7 +72,7 @@ const startWasiTask = async () => {
   // Instantiate the WebAssembly file
   const wasmBytes = new Uint8Array(responseArrayBuffer).buffer;
   const { instance } = await WebAssembly.instantiate(wasmBytes, {
-    wasi_snapshot_preview1: wasi.wasiImport,
+    wasi_snapshot_preview1: wrapWASI(wasi),
     javascript_kit: swift.importObjects(),
   });
 

--- a/entrypoint/dev.js
+++ b/entrypoint/dev.js
@@ -64,6 +64,24 @@ const wasi = new WASI({
   },
 });
 
+const wrapWASI = (wasiObject) => {
+  // PATCH: @wasmer-js/wasi@0.x forgets to call `refreshMemory` in `clock_res_get`,
+  // which writes its result to memory view. Without the refresh the memory view,
+  // it accesses a detached array buffer if the memory is grown by malloc.
+  // But they wasmer team discarded the 0.x codebase at all and replaced it with
+  // a new implementation written in Rust. The new version 1.x is really unstable
+  // and not production-ready as far as katei investigated in Apr 2022.
+  // So override the broken implementation of `clock_res_get` here instead of
+  // fixing the wasi polyfill.
+  // Reference: https://github.com/wasmerio/wasmer-js/blob/55fa8c17c56348c312a8bd23c69054b1aa633891/packages/wasi/src/index.ts#L557
+  const original_clock_res_get = wasiObject.wasiImport["clock_res_get"];
+  wasiObject.wasiImport["clock_res_get"] = (clockId, resolution) => {
+    wasiObject.refreshMemory();
+    return original_clock_res_get(clockId, resolution)
+  };
+  return wasiObject.wasiImport;
+}
+
 const startWasiTask = async () => {
   // Fetch our Wasm File
   const response = await fetch("/main.wasm");
@@ -72,7 +90,7 @@ const startWasiTask = async () => {
   // Instantiate the WebAssembly file
   const wasmBytes = new Uint8Array(responseArrayBuffer).buffer;
   const { instance } = await WebAssembly.instantiate(wasmBytes, {
-    wasi_snapshot_preview1: wasi.wasiImport,
+    wasi_snapshot_preview1: wrapWASI(wasi),
     javascript_kit: swift.importObjects(),
     __stack_sanitizer: {
       report_stack_overflow: () => {

--- a/entrypoint/test.js
+++ b/entrypoint/test.js
@@ -64,6 +64,24 @@ const wasi = new WASI({
   },
 });
 
+const wrapWASI = (wasiObject) => {
+  // PATCH: @wasmer-js/wasi@0.x forgets to call `refreshMemory` in `clock_res_get`,
+  // which writes its result to memory view. Without the refresh the memory view,
+  // it accesses a detached array buffer if the memory is grown by malloc.
+  // But they wasmer team discarded the 0.x codebase at all and replaced it with
+  // a new implementation written in Rust. The new version 1.x is really unstable
+  // and not production-ready as far as katei investigated in Apr 2022.
+  // So override the broken implementation of `clock_res_get` here instead of
+  // fixing the wasi polyfill.
+  // Reference: https://github.com/wasmerio/wasmer-js/blob/55fa8c17c56348c312a8bd23c69054b1aa633891/packages/wasi/src/index.ts#L557
+  const original_clock_res_get = wasiObject.wasiImport["clock_res_get"];
+  wasiObject.wasiImport["clock_res_get"] = (clockId, resolution) => {
+    wasiObject.refreshMemory();
+    return original_clock_res_get(clockId, resolution)
+  };
+  return wasiObject.wasiImport;
+}
+
 const startWasiTask = async () => {
   // Fetch our Wasm File
   const response = await fetch("/main.wasm");
@@ -72,7 +90,7 @@ const startWasiTask = async () => {
   // Instantiate the WebAssembly file
   const wasmBytes = new Uint8Array(responseArrayBuffer).buffer;
   const { instance } = await WebAssembly.instantiate(wasmBytes, {
-    wasi_snapshot_preview1: wasi.wasiImport,
+    wasi_snapshot_preview1: wrapWASI(wasi),
     javascript_kit: swift.importObjects(),
     __stack_sanitizer: {
       report_stack_overflow: () => {


### PR DESCRIPTION
This PRs just basically apply the same patch that was done in the WasmTransformer repo. https://github.com/swiftwasm/WasmTransformer/blob/main/Fixtures/index.js#L4-L27

It is overriding the implementation of `clock_res_get` in order to solve a memory issue.
It is applied to all the entry points that `carton` has.

This PR should closes #321 .

Thanks