### PR TITLE
Fix 5.6 template: use `executableTarget`

### DIFF
--- a/Sources/CartonKit/Model/Template.swift
+++ b/Sources/CartonKit/Model/Template.swift
@@ -109,7 +109,7 @@ extension Template {
               \(dependencies.map(\.description).joined(separator: ",\n"))
           ],
           targets: [
-              .target(
+              .executableTarget(
                   name: "\(project.name)",
                   dependencies: [
                       \(targetDepencencies.map(\.description).joined(separator: ",\n"))


### PR DESCRIPTION
Basic `target` is now deprecated in Swift 5.6 package manifests.