### PR TITLE
Serve all available resources with `dev`/`bundle`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,7 +8,7 @@ disabled_rules:
   - opening_brace
   - todo
 
-line_length: 100
+line_length: 120
 
 function_body_length: 50
 

--- a/Sources/CartonCLI/Commands/Bundle.swift
+++ b/Sources/CartonCLI/Commands/Bundle.swift
@@ -155,10 +155,10 @@ struct Bundle: AsyncParsableCommand {
     )
 
     let manifest = try toolchain.manifest.get()
-    for target in manifest.targets where target.type == .regular && !target.resources.isEmpty {
-      let targetPath = manifest.resourcesPath(for: target)
-      let resourcesPath = buildDirectory.appending(component: targetPath)
-      let targetDirectory = bundleDirectory.appending(component: targetPath)
+
+    for directoryName in try localFileSystem.resourcesDirectoryNames(relativeTo: buildDirectory) {
+      let resourcesPath = buildDirectory.appending(component: directoryName)
+      let targetDirectory = bundleDirectory.appending(component: directoryName)
 
       guard localFileSystem.exists(resourcesPath) else { continue }
       terminal.logLookup("Copying resources to ", targetDirectory)
@@ -168,7 +168,6 @@ struct Bundle: AsyncParsableCommand {
     /* While a product may be composed of multiple targets, not sure this is widely used in
      practice. Just assuming here that the first target of this product is an executable target,
      at least until SwiftPM allows specifying executable targets explicitly, as proposed in
-     swiftlint:disable:next line_length
      https://forums.swift.org/t/pitch-ability-to-declare-executable-targets-in-swiftpm-manifests-to-support-main/41968
      */
     let inferredMainTarget = manifest.targets.first {

--- a/Sources/CartonHelpers/FileSystem.swift
+++ b/Sources/CartonHelpers/FileSystem.swift
@@ -49,4 +49,10 @@ public extension FileSystem {
     // FIXME: should use `UnitInformationStorage`, but it's unavailable in open-source Foundation
     return try String(format: "%.2f MB", Double(getFileInfo(path).size) / 1024 / 1024)
   }
+
+  func resourcesDirectoryNames(relativeTo buildDirectory: AbsolutePath) throws -> [String] {
+    try getDirectoryContents(buildDirectory).filter {
+      $0.hasSuffix(".resources") && isDirectory(buildDirectory.appending(component: $0))
+    }
+  }
 }

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -142,7 +142,7 @@ public actor Server {
     app = Application(env)
     watcher = nil
 
-    app.configure(
+    try app.configure(
       .init(
         port: configuration.port,
         host: configuration.host,


### PR DESCRIPTION
Resolves https://github.com/swiftwasm/carton/issues/175.

I initially thought we should parse `Package.swift` manifests of the whole dependency tree to collect paths to resources from them, but now I'm not even sure that SwiftPM provides an API for this.

Much simpler solution is to serve with `dev` and copy with `bundle` all directories with `.resources` suffixes in the build directory. I think it's quite impossible to stumble upon unrelated directories with this approach, while it still resolves the issue as intended, in my opinion.