### PR TITLE
Fix JavaScriptBigIntSupport compatibility issue

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/swiftwasm/WasmTransformer",
         "state": {
           "branch": null,
-          "revision": "a6d18ccfe15bb0cc93799296909101236e47ad3b",
-          "version": "0.0.4"
+          "revision": "b5255decea7ac2e3ff674f5f433d499b2b971ebb",
+          "version": "0.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
     .package(url: "https://github.com/JohnSundell/Splash.git", from: "0.16.0"),
     .package(
       url: "https://github.com/swiftwasm/WasmTransformer",
-      .upToNextMinor(from: "0.0.4")
+      .upToNextMinor(from: "0.3.0")
     ),
   ],
   targets: [

--- a/Sources/CartonCLI/Commands/Bundle.swift
+++ b/Sources/CartonCLI/Commands/Bundle.swift
@@ -51,7 +51,7 @@ struct Bundle: AsyncParsableCommand {
 
   func buildFlavor() -> BuildFlavor {
     BuildFlavor(
-      isRelease: !debug, environment: .browser,
+      isRelease: !debug, environment: .defaultBrowser,
       sanitize: nil, swiftCompilerFlags: buildOptions.swiftCompilerFlags
     )
   }

--- a/Sources/CartonCLI/Commands/Dev.swift
+++ b/Sources/CartonCLI/Commands/Dev.swift
@@ -64,7 +64,7 @@ struct Dev: AsyncParsableCommand {
   func buildFlavor() -> BuildFlavor {
     let defaultSanitize: SanitizeVariant? = release ? nil : .stackOverflow
     return BuildFlavor(
-      isRelease: release, environment: .browser,
+      isRelease: release, environment: .defaultBrowser,
       sanitize: sanitize ?? defaultSanitize,
       swiftCompilerFlags: buildOptions.swiftCompilerFlags
     )

--- a/Sources/CartonCLI/Commands/Test.swift
+++ b/Sources/CartonCLI/Commands/Test.swift
@@ -18,25 +18,7 @@ import CartonKit
 import SwiftToolchain
 import TSCBasic
 
-private enum Environment: String, CaseIterable, ExpressibleByArgument {
-  static var allCasesNames: [String] { Environment.allCases.map { $0.rawValue } }
-
-  case wasmer
-  case node
-  case defaultBrowser
-
-  var destination: DestinationEnvironment {
-    switch self {
-    case .defaultBrowser:
-      return .browser
-    case .wasmer:
-      return .other
-    case .node:
-      return .browser
-    }
-  }
-
-}
+extension Environment: ExpressibleByArgument {}
 
 extension SanitizeVariant: ExpressibleByArgument {}
 
@@ -80,7 +62,7 @@ struct Test: AsyncParsableCommand {
   private var buildFlavor: BuildFlavor {
     BuildFlavor(
       isRelease: release,
-      environment: environment.destination,
+      environment: environment,
       sanitize: sanitize,
       swiftCompilerFlags: buildOptions.swiftCompilerFlags
     )

--- a/Sources/SwiftToolchain/BuildFlavor.swift
+++ b/Sources/SwiftToolchain/BuildFlavor.swift
@@ -16,15 +16,27 @@ public enum SanitizeVariant: String, CaseIterable {
   case stackOverflow
 }
 
+/// The target environment to build for.
+/// `Environment` doesn't specify the concrete environment, but the type of environments enough for build planning.
+public enum Environment: String, CaseIterable {
+  public static var allCasesNames: [String] { Environment.allCases.map { $0.rawValue } }
+
+  // TODO: Rename to `commandLine` to avoid confusion
+  case wasmer
+  case node
+  case defaultBrowser
+
+}
+
 public struct BuildFlavor {
   public var isRelease: Bool
-  public var environment: DestinationEnvironment
+  public var environment: Environment
   public var sanitize: SanitizeVariant?
   public var swiftCompilerFlags: [String]
 
   public init(
     isRelease: Bool,
-    environment: DestinationEnvironment,
+    environment: Environment,
     sanitize: SanitizeVariant?,
     swiftCompilerFlags: [String]
   ) {

--- a/Sources/SwiftToolchain/Builder.swift
+++ b/Sources/SwiftToolchain/Builder.swift
@@ -56,7 +56,7 @@ public final class Builder {
     )
 
     var transformers: [(inout InputByteStream, inout InMemoryOutputWriter) throws -> ()] = []
-    if self.flavor.environment != .other {
+    if self.flavor.environment != .wasmer {
       transformers.append(I64ImportTransformer().transform)
     }
 

--- a/Sources/SwiftToolchain/Builder.swift
+++ b/Sources/SwiftToolchain/Builder.swift
@@ -56,8 +56,19 @@ public final class Builder {
     )
 
     var transformers: [(inout InputByteStream, inout InMemoryOutputWriter) throws -> ()] = []
-    if self.flavor.environment != .wasmer {
-      transformers.append(I64ImportTransformer().transform)
+    if self.flavor.environment == .node || self.flavor.environment == .defaultBrowser {
+      // If building for JS-host environments,
+      // - i64 params in imports are not supported without bigint-i64 feature
+      // - The param types in imports don't have to be strictly same as host expected
+      // - Users cannot avoid having such imports come from WASI since they are
+      //   mandatory imports.
+      //
+      // So lower i64 param types to be i32. It happens *only for WASI imports*
+      // since users can avoid such imports coming from other user modules.
+      let transformer = I64ImportTransformer(shouldLower: {
+        $0.module == "wasi_snapshot_preview1" || $0.module == "wasi_unstable"
+      })
+      transformers.append(transformer.transform)
     }
 
     switch self.flavor.sanitize {

--- a/Sources/SwiftToolchain/DestinationEnvironment.swift
+++ b/Sources/SwiftToolchain/DestinationEnvironment.swift
@@ -20,7 +20,6 @@ public enum DestinationEnvironment {
   case firefox
   case chrome
   case edge
-  case browser
 }
 
 public extension String {

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -359,7 +359,7 @@ public final class Toolchain {
 
     // SwiftWasm 5.6 requires reactor model from updated wasi-libc when not building as a command
     // see https://github.com/WebAssembly/WASI/issues/13
-    if version.starts(with: "wasm-5.6") && flavor.environment != .other {
+    if version.starts(with: "wasm-5.6") && flavor.environment != .wasmer {
       builderArguments.append(contentsOf: [
         "-Xswiftc", "-Xclang-linker", "-Xswiftc", "-mexec-model=reactor",
         "-Xlinker", "--export=main",


### PR DESCRIPTION
This PR includes:

- Refactoring for the consistency of use of `DestinationEnvironment` and `Environment`
- And fix for `JavaScriptBigIntSupport` compatibility issue: Close https://github.com/swiftwasm/carton/issues/326

