### PR TITLE
Use `--static-swift-stdlib` for easier distribution

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build the project
         run: |
           swift -v
-          swift build -Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none
+          swift build -Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none --static-swift-stdlib
 
       - name: Build and install JavaScript and sanitizer resources
         run: |


### PR DESCRIPTION
In theory this should allow us to distribute self-contained binaries on Linux.