### PR TITLE
Fix watcher breakage on failed builds

### DIFF
--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -201,6 +201,8 @@ public actor Server {
     }
 
     isBuildCurrentlyRunning = true
+    defer { isBuildCurrentlyRunning = false }
+
     // `configuration.builder` is guaranteed to be non-nil here as its presence is checked in `init`
     try await run(configuration.builder!, configuration.terminal)
 
@@ -213,7 +215,6 @@ public actor Server {
     }
 
     isSubsequentBuildScheduled = false
-    isBuildCurrentlyRunning = false
   }
 
   private func add(pendingChanges: [AbsolutePath]) {}

--- a/Tests/Fixtures/NodeJSKitTest/.gitignore
+++ b/Tests/Fixtures/NodeJSKitTest/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.vscode


### PR DESCRIPTION
After switching to `async`/`await` the value of `isBuildCurrentlyRunning` wasn't correctly reset, which led to issues. By resetting the variable in `defer` we guarantee that it will be reset even when errors are thrown.

Resolves #339.