### PR TITLE
Fix symlinks not fully cleaned up in Node.js tests

### DIFF
--- a/Sources/CartonHelpers/FileSystem.swift
+++ b/Sources/CartonHelpers/FileSystem.swift
@@ -52,7 +52,7 @@ public extension FileSystem {
 
   func resourcesDirectoryNames(relativeTo buildDirectory: AbsolutePath) throws -> [String] {
     try getDirectoryContents(buildDirectory).filter {
-      $0.hasSuffix(".resources") && isDirectory(buildDirectory.appending(component: $0))
+      $0.hasSuffix(".resources")
     }
   }
 }


### PR DESCRIPTION
`FileSystem.isDirectory` returns `false` when running it on broken symlinks, which breaks Node.js tests flow. We should be able to clean up all symlinks, even broken ones. Other we can't create new correct symlinks because broken symlinks already exist at those paths.