### PR TITLE
Add missing check for Node.js entrypoint

### DIFF
--- a/Sources/CartonCLI/Commands/TestRunners/NodeTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/NodeTestRunner.swift
@@ -31,6 +31,7 @@ struct NodeTestRunner: TestRunner {
   func run() async throws {
     terminal.write("\nRunning the test bundle with Node.js:\n", inColor: .yellow)
 
+    try Constants.entrypoint.check(on: localFileSystem, terminal)
     let (_, _, entrypointPath) = Constants.entrypoint.paths(on: localFileSystem)
 
     // Allow Node.js to resolve modules from resource directories by making them relative to the entrypoint path.


### PR DESCRIPTION
Because of the lack of this check the entrypoint files weren't unpacked when missing on `carton test --environment node` runs.