### PR TITLE
Add `<!DOCTYPE html>` to default `index.html`

### DIFF
--- a/Sources/CartonKit/Server/HTML.swift
+++ b/Sources/CartonKit/Server/HTML.swift
@@ -60,6 +60,7 @@ extension HTML: ResponseEncodable {
     }
 
     return #"""
+    <!DOCTYPE html>
     <html>
       <head>
           <meta charset="utf-8" />


### PR DESCRIPTION
As suggested by @carson-katri the prevents browsers from using quirks mode by default.