### PR TITLE
Stop limiting WS frame size to 16kb for large number of test suites

### DIFF
--- a/Sources/CartonKit/Server/Application.swift
+++ b/Sources/CartonKit/Server/Application.swift
@@ -59,7 +59,8 @@ extension Application {
       }
     }
 
-    webSocket("watcher") { request, ws in
+    // Don't limit the size of frame to accept large test outputs
+    webSocket("watcher", maxFrameSize: .init(integerLiteral: Int(UInt32.max))) { request, ws in
       let environment = request.headers["User-Agent"].compactMap(DestinationEnvironment.init).first
         ?? .other
 


### PR DESCRIPTION
The output of production-scale test suites couldn't fit within [the default frame size limit 16kb](https://github.com/vapor/vapor/blob/50599e242043edcc2ed79b2b067233efef65dbd3/Sources/Vapor/Routing/RoutesBuilder%2BWebSocket.swift#L9)...