### PR TITLE
Add --bundle-path option to `carton test`

### DIFF
--- a/Sources/CartonCLI/Commands/Test.swift
+++ b/Sources/CartonCLI/Commands/Test.swift
@@ -56,9 +56,8 @@ struct Test: AsyncParsableCommand {
   )
   var host = "127.0.0.1"
 
-  @Flag(name: .customLong("skip-build"),
-        help: "Skip building the test target")
-  var shouldSkipBuilding: Bool = false
+  @Option(help: "Use the given bundle instead of building the test target")
+  var bundlePath: String?
 
   @OptionGroup()
   var buildOptions: BuildOptions
@@ -76,8 +75,8 @@ struct Test: AsyncParsableCommand {
     let terminal = InteractiveWriter.stdout
     let toolchain = try await Toolchain(localFileSystem, terminal)
     let bundlePath: AbsolutePath
-    if shouldSkipBuilding {
-      bundlePath = try toolchain.getTestProduct(flavor: buildFlavor).artifactPath
+    if let preBundlePath = self.bundlePath {
+      bundlePath = AbsolutePath(preBundlePath, relativeTo: localFileSystem.currentWorkingDirectory!)
       guard localFileSystem.exists(bundlePath) else {
         terminal.write(
           "No built binary found in \(bundlePath)\n",

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -302,14 +302,19 @@ public final class Toolchain {
     return .init(arguments: builderArguments, mainWasmPath: mainWasmPath, product: product)
   }
 
-  /// Returns an absolute path to the resulting test bundle
-  public func buildTestBundle(
-    flavor: BuildFlavor
-  ) async throws -> AbsolutePath {
+  public func getTestProduct(flavor: BuildFlavor) throws -> (name: String, artifactPath: AbsolutePath) {
     let manifest = try manifest.get()
     let binPath = try inferBinPath(isRelease: flavor.isRelease)
     let testProductName = "\(manifest.displayName)PackageTests"
     let testBundlePath = binPath.appending(component: "\(testProductName).wasm")
+    return (testProductName, testBundlePath)
+  }
+
+  /// Returns an absolute path to the resulting test bundle
+  public func buildTestBundle(
+    flavor: BuildFlavor
+  ) async throws -> AbsolutePath {
+    let (testProductName, testBundlePath) = try getTestProduct(flavor: flavor)
     terminal.logLookup("- test bundle to run: ", testBundlePath.pathString)
 
     terminal.write(

--- a/Tests/CartonCommandTests/TestCommandTests.swift
+++ b/Tests/CartonCommandTests/TestCommandTests.swift
@@ -64,7 +64,7 @@ final class TestCommandTests: XCTestCase {
         cwd: packageDirectory.url
       )
       AssertExecuteCommand(
-        command: "carton test --environment node --skip-build",
+        command: "carton test --environment node --bundle-path ./.build/wasm32-unknown-wasi/debug/NodeJSKitTestPackageTests.wasm",
         cwd: packageDirectory.url
       )
     }

--- a/Tests/CartonCommandTests/TestCommandTests.swift
+++ b/Tests/CartonCommandTests/TestCommandTests.swift
@@ -57,6 +57,19 @@ final class TestCommandTests: XCTestCase {
     }
   }
 
+  func testSkipBuild() throws {
+    try withFixture(Constants.nodeJSKitPackageName) { packageDirectory in
+      AssertExecuteCommand(
+        command: "carton test --environment node",
+        cwd: packageDirectory.url
+      )
+      AssertExecuteCommand(
+        command: "carton test --environment node --skip-build",
+        cwd: packageDirectory.url
+      )
+    }
+  }
+
   // This test is prone to hanging on Linux.
   #if os(macOS)
   func testEnvironmentDefaultBrowser() throws {


### PR DESCRIPTION
This allows users to build their projects in their responsibilities with custom options.