### PR TITLE
Add option to disable wasm optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ files except `index.html` are named by their content hashes to enable [cache
 busting](https://www.keycdn.com/support/what-is-cache-busting). As with `carton dev`, a custom
 `index.html` page can be provided through the `--custom-index-page` option. You can also pass
 `--debug-info` flag to preserve `names` and DWARF sections in the resulting `.wasm` file, as these
-are stripped in the `release` configuration by default.
+are stripped in the `release` configuration by default. By default, `carton bundle` will run `wasm-opt`
+on the resulting .wasm binary in order to reduce its file size. That behaviour can be disabled (in order
+to speed up the build) by appending the `--wasm-optimizations none` option.
 
 The `carton package` command proxies its subcommands to `swift package` invocations on the
 currently-installed toolchain. This may be useful in situations where you'd like to generate an

--- a/Sources/CartonCLI/Commands/Bundle.swift
+++ b/Sources/CartonCLI/Commands/Bundle.swift
@@ -48,7 +48,12 @@ struct Bundle: AsyncParsableCommand {
 
   @Option(
     name: .long,
-    help: "Which optimizations to apply to the .wasm binary output.\n Available values: \(WasmOptimizations.allCases.map { $0.rawValue }.joined(separator: ", "))"
+    help: """
+        Which optimizations to apply to the .wasm binary output.
+        Available values: \(
+            WasmOptimizations.allCases.map { $0.rawValue }.joined(separator: ", ")
+        )
+        """
   )
   var wasmOptimizations: WasmOptimizations = .size
 

--- a/Sources/CartonCLI/Commands/Bundle.swift
+++ b/Sources/CartonCLI/Commands/Bundle.swift
@@ -49,11 +49,11 @@ struct Bundle: AsyncParsableCommand {
   @Option(
     name: .long,
     help: """
-        Which optimizations to apply to the .wasm binary output.
-        Available values: \(
-            WasmOptimizations.allCases.map { $0.rawValue }.joined(separator: ", ")
-        )
-        """
+    Which optimizations to apply to the .wasm binary output.
+    Available values: \(
+      WasmOptimizations.allCases.map(\.rawValue).joined(separator: ", ")
+    )
+    """
   )
   var wasmOptimizations: WasmOptimizations = .size
 
@@ -101,7 +101,7 @@ struct Bundle: AsyncParsableCommand {
     let bundleDirectory = AbsolutePath(localFileSystem.currentWorkingDirectory!, "Bundle")
     try localFileSystem.removeFileTree(bundleDirectory)
     try localFileSystem.createDirectory(bundleDirectory)
-    
+
     let wasmOutputFilePath = AbsolutePath(bundleDirectory, "main.wasm")
 
     if wasmOptimizations == .size {

--- a/Sources/CartonCLI/Commands/Bundle.swift
+++ b/Sources/CartonCLI/Commands/Bundle.swift
@@ -46,8 +46,12 @@ struct Bundle: AsyncParsableCommand {
   @Flag(help: "Emit names and DWARF sections in the .wasm file.")
   var debugInfo: Bool = false
 
-  @Option(name: .long,
-          help: "Which optimizations to apply to the .wasm binary output.\nAvailable values: \(WasmOptimizations.allCases.map { $0.rawValue }.joined(separator: ", "))")
+  @Option(
+    name: .long,
+    help: "Which optimizations to apply to the .wasm binary output.\nAvailable values: \(
+      WasmOptimizations.allCases.map { $0.rawValue }.joined(separator: ", ")
+    )"
+  )
   var wasmOptimizations: WasmOptimizations = .size
 
   @OptionGroup()

--- a/Sources/CartonCLI/Commands/Bundle.swift
+++ b/Sources/CartonCLI/Commands/Bundle.swift
@@ -48,9 +48,7 @@ struct Bundle: AsyncParsableCommand {
 
   @Option(
     name: .long,
-    help: "Which optimizations to apply to the .wasm binary output.\nAvailable values: \(
-      WasmOptimizations.allCases.map { $0.rawValue }.joined(separator: ", ")
-    )"
+    help: "Which optimizations to apply to the .wasm binary output.\n Available values: \(WasmOptimizations.allCases.map { $0.rawValue }.joined(separator: ", "))"
   )
   var wasmOptimizations: WasmOptimizations = .size
 


### PR DESCRIPTION
I am trying to implement an `esbuild` plugin that calls into `carton`. My plan was to call `carton bundle --debug` to get a quick development build and then extract that command's output for use in our esbuild project.

Unfortunately, `carton bundle` still runs `wasm-opt` even on a debug build, which takes 5-10s for our project. The only alternative I can see is `carton dev`, but that runs the dev server / watcher, which we don't want either for a one-off build.

Since changing the behaviour of `carton bundle --debug` to _not_ run `wasm-opt` may cause issues with backwards compatibility, @MaxDesiatov suggested we add a command line option `--wasm-optimizations {size, none}` instead, allowing users to specifically opt out of this behaviour.

The current PR implements the new `--wasm-optimizations` option, as can be seen in the screenshot below:

<img width="777" alt="image" src="https://user-images.githubusercontent.com/5485935/171055742-02b79eaa-c6a0-47b0-aafd-5265b8ee5399.png">
