### PR TITLE
Headless test runner

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -86,7 +86,7 @@ let package = Package(
       ]
     ),
     .target(name: "WebDriverClient", dependencies: [
-        .product(name: "AsyncHTTPClient", package: "async-http-client"),
+      .product(name: "AsyncHTTPClient", package: "async-http-client"),
     ]),
     // This target is used only for release automation tasks and
     // should not be installed by `carton` users.

--- a/Package.swift
+++ b/Package.swift
@@ -87,6 +87,7 @@ let package = Package(
     ),
     .target(name: "WebDriverClient", dependencies: [
       .product(name: "AsyncHTTPClient", package: "async-http-client"),
+      .product(name: "NIOFoundationCompat", package: "swift-nio"),
     ]),
     // This target is used only for release automation tasks and
     // should not be installed by `carton` users.

--- a/Package.swift
+++ b/Package.swift
@@ -63,6 +63,7 @@ let package = Package(
         .product(name: "Vapor", package: "vapor"),
         "CartonHelpers",
         "SwiftToolchain",
+        "WebDriverClient",
       ]
     ),
     .target(
@@ -84,6 +85,9 @@ let package = Package(
         "WasmTransformer",
       ]
     ),
+    .target(name: "WebDriverClient", dependencies: [
+        .product(name: "AsyncHTTPClient", package: "async-http-client"),
+    ]),
     // This target is used only for release automation tasks and
     // should not be installed by `carton` users.
     .executableTarget(
@@ -112,5 +116,6 @@ let package = Package(
         .product(name: "TSCTestSupport", package: "swift-tools-support-core"),
       ]
     ),
+    .testTarget(name: "WebDriverClientTests", dependencies: ["WebDriverClient"]),
   ]
 )

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ either: `wasmer`, `node` or `defaultBrowser`. Code that depends on
 the test run will not succeed, since JavaScript environment is not available with `--environment wasmer`.
 If you want to run your test suite on CI or without GUI but on browser, you can pass `--headless` flag.
 It enables [WebDriver](https://w3c.github.io/webdriver/)-based headless browser testing. Note that you
-need to install a WebDriver in `PATH` before running tests.
+need to install a WebDriver executable in `PATH` before running tests.
 You can use the command with a prebuilt test bundle binary instead of building it in carton by passing
 `--prebuilt-test-bundle-path <your binary path>`.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ either: `wasmer`, `node` or `defaultBrowser`. Code that depends on
 [JavaScriptKit](https://github.com/swiftwasm/JavaScriptKit) should pass either `--environment node` or
 `--environment defaultBrowser` options, depending on whether it needs Web APIs to work. Otherwise
 the test run will not succeed, since JavaScript environment is not available with `--environment wasmer`.
+If you want to run your test suite on CI or without GUI but on browser, you can pass `--headless` flag.
+It enables [WebDriver](https://w3c.github.io/webdriver/)-based headless browser testing. Note that you
+need to install a WebDriver in `PATH` before running tests.
 You can use the command with a prebuilt test bundle binary instead of building it in carton by passing
 `--prebuilt-test-bundle-path <your binary path>`.
 

--- a/Sources/CartonCLI/Commands/Dev.swift
+++ b/Sources/CartonCLI/Commands/Dev.swift
@@ -112,7 +112,7 @@ struct Dev: AsyncParsableCommand {
 
     let sources = try paths.flatMap { try localFileSystem.traverseRecursively($0) }
 
-    try await Server(
+    let server = try await Server(
       .init(
         builder: Builder(
           arguments: build.arguments,
@@ -124,7 +124,6 @@ struct Dev: AsyncParsableCommand {
         ),
         mainWasmPath: build.mainWasmPath,
         verbose: verbose,
-        shouldSkipAutoOpen: skipAutoOpen,
         port: port,
         host: host,
         customIndexPath: customIndexPage.map { AbsolutePath($0, relativeTo: localFileSystem.currentWorkingDirectory!) },
@@ -134,6 +133,11 @@ struct Dev: AsyncParsableCommand {
         entrypoint: Self.entrypoint,
         terminal: terminal
       )
-    ).run()
+    )
+    try await server.start()
+    if !skipAutoOpen {
+      await openInSystemBrowser(url: server.localURL)
+    }
+    try await server.waitUntilStop()
   }
 }

--- a/Sources/CartonCLI/Commands/Dev.swift
+++ b/Sources/CartonCLI/Commands/Dev.swift
@@ -134,9 +134,9 @@ struct Dev: AsyncParsableCommand {
         terminal: terminal
       )
     )
-    try await server.start()
+    let localURL = try await server.start()
     if !skipAutoOpen {
-      await openInSystemBrowser(url: server.localURL)
+      openInSystemBrowser(url: localURL)
     }
     try await server.waitUntilStop()
   }

--- a/Sources/CartonCLI/Commands/Test.swift
+++ b/Sources/CartonCLI/Commands/Test.swift
@@ -45,6 +45,9 @@ struct Test: AsyncParsableCommand {
   )
   private var environment = Environment.wasmer
 
+  // It implemented as a separate flag instead of a `--environment` variant because `--environment`
+  // is designed to accept specific browser names in the future like `--environment firefox`. 
+  // Then `--headless` should be able to be used with `defaultBrowser` and other browser values.
   @Flag(help: "When running browser tests, run the browser in headless mode")
   var headless: Bool = false
 

--- a/Sources/CartonCLI/Commands/Test.swift
+++ b/Sources/CartonCLI/Commands/Test.swift
@@ -22,6 +22,10 @@ extension Environment: ExpressibleByArgument {}
 
 extension SanitizeVariant: ExpressibleByArgument {}
 
+struct TestError: Error, CustomStringConvertible {
+  let description: String
+}
+
 struct Test: AsyncParsableCommand {
 
   static let configuration = CommandConfiguration(abstract: "Run the tests in a WASI environment.")
@@ -40,6 +44,9 @@ struct Test: AsyncParsableCommand {
       "Environment used to run the tests. Available values: \(Environment.allCasesNames.joined(separator: ", "))"
   )
   private var environment = Environment.wasmer
+
+  @Flag(help: "When running browser tests, run the browser in headless mode")
+  var headless: Bool = false
 
   @Option(help: "Turn on runtime checks for various behavior.")
   private var sanitize: SanitizeVariant?
@@ -69,6 +76,12 @@ struct Test: AsyncParsableCommand {
       sanitize: sanitize,
       swiftCompilerFlags: buildOptions.swiftCompilerFlags
     )
+  }
+
+  func validate() throws {
+    if headless && environment != .defaultBrowser {
+      throw TestError(description: "The `--headless` flag can be applied only for browser environments")
+    }
   }
 
   func run() async throws {
@@ -101,6 +114,7 @@ struct Test: AsyncParsableCommand {
         testFilePath: bundlePath,
         host: host,
         port: port,
+        headless: headless,
         // swiftlint:disable:next force_try
         manifest: try! toolchain.manifest.get(),
         terminal: terminal

--- a/Sources/CartonCLI/Commands/Test.swift
+++ b/Sources/CartonCLI/Commands/Test.swift
@@ -45,9 +45,9 @@ struct Test: AsyncParsableCommand {
   )
   private var environment = Environment.wasmer
 
-  // It implemented as a separate flag instead of a `--environment` variant because `--environment`
-  // is designed to accept specific browser names in the future like `--environment firefox`. 
-  // Then `--headless` should be able to be used with `defaultBrowser` and other browser values.
+  /// It is implemented as a separate flag instead of a `--environment` variant because `--environment`
+  /// is designed to accept specific browser names in the future like `--environment firefox`. 
+  /// Then `--headless` should be able to be used with `defaultBrowser` and other browser values.
   @Flag(help: "When running browser tests, run the browser in headless mode")
   var headless: Bool = false
 

--- a/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
@@ -151,7 +151,7 @@ struct BrowserTestRunner: TestRunner {
       ),
       .shared(eventLoopGroup)
     )
-    try await server.start()
+    let localURL = try await server.start()
     var disposer: () async throws -> () = {}
     do {
       if headless {
@@ -161,10 +161,10 @@ struct BrowserTestRunner: TestRunner {
           try await client.closeSession()
           clientDisposer()
         }
-        try await client.goto(url: server.localURL)
+        try await client.goto(url: localURL)
       } else {
         disposer = {}
-        await openInSystemBrowser(url: server.localURL)
+        openInSystemBrowser(url: localURL)
       }
       try await server.waitUntilStop()
       try await disposer()

--- a/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
@@ -36,10 +36,10 @@ enum BrowserTestRunnerError: Error, CustomStringConvertible {
     case .failedToFindWebDriver:
       return """
       Failed to find WebDriver executable or remote URL to a running driver process.
-      Please make sure that you satisfied one of the followings (smaller item number lower priority):
-      1. `chromedriver`, `geckodriver`, `safaridriver`, or `msedgedriver` has been installed in `PATH`
+      Please make sure that you are satisfied with one of the followings (in order of priority)
+      1. Set `WEBDRIVER_REMOTE_URL` with the address of remote WebDriver like `WEBDRIVER_REMOTE_URL=http://localhost:9515`.
       2. Set `WEBDRIVER_PATH` with the path to your WebDriver executable.
-      3. Set `WEBDRIVER_REMOTE_URL` with the address of remote WebDriver like `WEBDRIVER_REMOTE_URL=http://localhost:9515`.
+      3. `chromedriver`, `geckodriver`, `safaridriver`, or `msedgedriver` has been installed in `PATH`
       """
     }
   }

--- a/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
@@ -55,7 +55,7 @@ struct BrowserTestRunner: TestRunner {
   let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
   let httpClient: HTTPClient
 
-  internal init(
+  init(
     testFilePath: AbsolutePath,
     host: String,
     port: Int,

--- a/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
@@ -17,26 +17,117 @@ import CartonKit
 import Foundation
 import PackageModel
 import TSCBasic
+import WebDriverClient
+import AsyncHTTPClient
+import NIOCore
+import NIOPosix
 
 private enum Constants {
   static let entrypoint = Entrypoint(fileName: "test.js", sha256: testEntrypointSHA256)
+}
+
+enum BrowserTestRunnerError: Error, CustomStringConvertible {
+  case invalidRemoteURL(String)
+  case failedToFindDriver
+
+  var description: String {
+    switch self {
+    case .invalidRemoteURL(let url): return "Invalid remote URL: \(url)"
+    case .failedToFindDriver:
+      return """
+Failed to find WebDriver executable or remote URL to a running driver process.
+Please make sure that you satisfied one of the followings (smaller item number lower priority):
+1. `chromedriver`, `geckodriver`, `safaridriver`, or `msedgedriver` has been installed in `PATH`
+2. Set `WEBDRIVER_PATH` with the path to your WebDriver executable.
+3. Set `WEBDRIVER_REMOTE_URL` with the address of remote WebDriver like `WEBDRIVER_REMOTE_URL=http://localhost:9515`.
+"""
+    }
+  }
 }
 
 struct BrowserTestRunner: TestRunner {
   let testFilePath: AbsolutePath
   let host: String
   let port: Int
+  let headless: Bool
   let manifest: Manifest
   let terminal: InteractiveWriter
+  let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+  let httpClient: HTTPClient
+
+  internal init(testFilePath: AbsolutePath, host: String, port: Int, headless: Bool, manifest: Manifest, terminal: InteractiveWriter) {
+    self.testFilePath = testFilePath
+    self.host = host
+    self.port = port
+    self.headless = headless
+    self.manifest = manifest
+    self.terminal = terminal
+    self.httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
+  }
+
+  typealias Disposer = () -> Void
+
+  func findAvailablePort() async throws -> SocketAddress {
+    let bootstrap = ServerBootstrap(group: eventLoopGroup)
+    let address = try SocketAddress.makeAddressResolvingHost("127.0.0.1", port: 0)
+    let channel = try await bootstrap.bind(to: address).get()
+    let localAddr = channel.localAddress!
+    try await channel.close()
+    return localAddr
+  }
+  func launchDriver(executablePath: String) async throws -> (URL, Disposer) {
+    let address = try await findAvailablePort()
+    let process = Process(arguments: [
+      executablePath, "--port=\(address.port!)",
+    ])
+    try process.launch()
+    let disposer = { process.signal(SIGKILL) }
+    return (URL(string: "http://\(address.ipAddress!):\(address.port!)")!, disposer)
+  }
+
+  func makeWebDriverClient(httpClient: HTTPClient) async throws -> (WebDriverClient, Disposer) {
+    let strategies: [() async throws -> (URL, Disposer)?] = [
+      {
+        guard let value = ProcessInfo.processInfo.environment["WEBDRIVER_REMOTE_URL"] else {
+          return nil
+        }
+        guard let url = URL(string: value) else {
+          throw BrowserTestRunnerError.invalidRemoteURL(value)
+        }
+        return (url, {})
+      },
+      {
+        guard let executable = ProcessEnv.vars["WEBDRIVER_PATH"] else {
+          return nil
+        }
+        return try await launchDriver(executablePath: executable)
+      },
+      {
+        let driverCandidates = [
+          "chromedriver", "geckodriver", "safaridriver", "msedgedriver"
+        ]
+        guard let found = driverCandidates.lazy.compactMap({ Process.findExecutable($0) }).first else {
+          return nil
+        }
+        return try await launchDriver(executablePath: found.pathString)
+      }
+    ]
+    for strategy in strategies {
+      if let (url, disposer) = try await strategy() {
+        return (try await WebDriverClient.newSession(endpoint: url, httpClient: httpClient), disposer)
+      }
+    }
+    throw BrowserTestRunnerError.failedToFindDriver
+  }
 
   func run() async throws {
+    defer { try! httpClient.syncShutdown() }
     try Constants.entrypoint.check(on: localFileSystem, terminal)
-    try await Server(
+    let server = try await Server(
       .init(
         builder: nil,
         mainWasmPath: testFilePath,
         verbose: true,
-        shouldSkipAutoOpen: false,
         port: port,
         host: host,
         customIndexPath: nil,
@@ -44,7 +135,28 @@ struct BrowserTestRunner: TestRunner {
         product: nil,
         entrypoint: Constants.entrypoint,
         terminal: terminal
-      )
-    ).run()
+      ),
+      .shared(eventLoopGroup)
+    )
+    try await server.start()
+    var disposer: () async throws -> Void = {}
+    do {
+      if headless {
+        let (client, clientDisposer) = try await makeWebDriverClient(httpClient: httpClient)
+        disposer = {
+          try await client.closeSession()
+          clientDisposer()
+        }
+        try await client.goto(url: server.localURL)
+      } else {
+        disposer = {}
+        await openInSystemBrowser(url: server.localURL)
+      }
+      try await server.waitUntilStop()
+      try await disposer()
+    } catch {
+      try await disposer()
+      throw error
+    }
   }
 }

--- a/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
@@ -28,12 +28,12 @@ private enum Constants {
 
 enum BrowserTestRunnerError: Error, CustomStringConvertible {
   case invalidRemoteURL(String)
-  case failedToFindDriver
+  case failedToFindWebDriver
 
   var description: String {
     switch self {
     case let .invalidRemoteURL(url): return "Invalid remote URL: \(url)"
-    case .failedToFindDriver:
+    case .failedToFindWebDriver:
       return """
       Failed to find WebDriver executable or remote URL to a running driver process.
       Please make sure that you satisfied one of the followings (smaller item number lower priority):
@@ -130,7 +130,7 @@ struct BrowserTestRunner: TestRunner {
         return (url, disposer)
       }
     }
-    throw BrowserTestRunnerError.failedToFindDriver
+    throw BrowserTestRunnerError.failedToFindWebDriver
   }
 
   func run() async throws {

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -77,7 +77,7 @@ public actor Server {
   private let app: Application
 
   /// Local URL of this server, `https://128.0.0.1:8080/` by default.
-  public let localURL: String
+  private let localURL: String
 
   /// Whether a build that could be triggered by this server is currently running.
   private var isBuildCurrentlyRunning = false
@@ -219,8 +219,9 @@ public actor Server {
     connections.remove(connection)
   }
 
-  public func start() throws {
+  public func start() throws -> String {
     try app.start()
+    return localURL
   }
 
   /// Wait and handle the shutdown

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -220,14 +220,14 @@ public actor Server {
   }
 
   public func start() throws {
-      try self.app.start()
+    try app.start()
   }
 
   /// Wait and handle the shutdown
   public func waitUntilStop() async throws {
     defer { self.app.shutdown() }
-    try await self.app.running?.onStop.get()
-    try self.closeSockets()
+    try await app.running?.onStop.get()
+    try closeSockets()
   }
 
   func closeSockets() throws {

--- a/Sources/WebDriverClient/WebDriverClient.swift
+++ b/Sources/WebDriverClient/WebDriverClient.swift
@@ -33,16 +33,31 @@ public struct WebDriverClient {
         }
     }
 
-    public static func newSession(endpoint: URL, httpClient: HTTPClient) async throws -> WebDriverClient {
+    public static let defaultSessionRequestBody = #"""
+{
+  "capabilities": {
+    "alwaysMatch": {
+      "goog:chromeOptions": {
+        "w3c": true,
+        "args": ["--headless", "--no-sandbox"]
+      }
+    }
+  }
+}
+"""#
+
+    public static func newSession(endpoint: URL, body: String = defaultSessionRequestBody,
+                                  httpClient: HTTPClient) async throws -> WebDriverClient {
         struct Response: Decodable {
             let sessionId: String
         }
         struct Request: Encodable {
             let capabilities: [String: String] = [:]
+            let desiredCapabilities: [String: String] = [:]
         }
         let httpResponse = try await httpClient.post(
             url: endpoint.appendingPathComponent("session").absoluteString,
-            body: makeRequestBody(Request())
+            body: HTTPClient.Body.string(body)
         ).get()
         guard let responseBody = httpResponse.body else {
             throw WebDriverError.newSessionFailed(httpResponse)

--- a/Sources/WebDriverClient/WebDriverClient.swift
+++ b/Sources/WebDriverClient/WebDriverClient.swift
@@ -42,6 +42,9 @@ public struct WebDriverClient {
         },
         "moz:firefoxOptions": {
           "args": ["-headless"]
+        },
+        "ms:edgeOptions": {
+          "args": ["--headless", "--no-sandbox"]
         }
       }
     }

--- a/Sources/WebDriverClient/WebDriverClient.swift
+++ b/Sources/WebDriverClient/WebDriverClient.swift
@@ -12,91 +12,94 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
 import AsyncHTTPClient
+import Foundation
 
 public enum WebDriverError: Error {
-    case newSessionFailed(HTTPClient.Response)
+  case newSessionFailed(HTTPClient.Response)
 }
 
 public struct WebDriverClient {
+  let client: HTTPClient
+  let driverEndpoint: URL
+  let sessionId: String
 
-    let client: HTTPClient
-    let driverEndpoint: URL
-    let sessionId: String
-
-    @dynamicMemberLookup
-    struct ValueResponse<Value: Decodable>: Decodable {
-        let value: Value
-        subscript<T>(dynamicMember keyPath: KeyPath<Value, T>) -> T {
-            return self.value[keyPath: keyPath]
-        }
+  @dynamicMemberLookup
+  struct ValueResponse<Value: Decodable>: Decodable {
+    let value: Value
+    subscript<T>(dynamicMember keyPath: KeyPath<Value, T>) -> T {
+      self.value[keyPath: keyPath]
     }
+  }
 
-    public static let defaultSessionRequestBody = #"""
-{
-  "capabilities": {
-    "alwaysMatch": {
-      "goog:chromeOptions": {
-        "w3c": true,
-        "args": ["--headless", "--no-sandbox"]
+  public static let defaultSessionRequestBody = #"""
+  {
+    "capabilities": {
+      "alwaysMatch": {
+        "goog:chromeOptions": {
+          "w3c": true,
+          "args": ["--headless", "--no-sandbox"]
+        },
+        "moz:firefoxOptions": {
+          "args": ["-headless"]
+        }
       }
     }
   }
-}
-"""#
+  """#
 
-    public static func newSession(endpoint: URL, body: String = defaultSessionRequestBody,
-                                  httpClient: HTTPClient) async throws -> WebDriverClient {
-        struct Response: Decodable {
-            let sessionId: String
-        }
-        struct Request: Encodable {
-            let capabilities: [String: String] = [:]
-            let desiredCapabilities: [String: String] = [:]
-        }
-        let httpResponse = try await httpClient.post(
-            url: endpoint.appendingPathComponent("session").absoluteString,
-            body: HTTPClient.Body.string(body)
-        ).get()
-        guard let responseBody = httpResponse.body else {
-            throw WebDriverError.newSessionFailed(httpResponse)
-        }
-        let decoder = JSONDecoder()
-        let response = try decoder.decode(ValueResponse<Response>.self, from: responseBody)
-        return WebDriverClient(client: httpClient,
-                               driverEndpoint: endpoint,
-                               sessionId: response.sessionId)
+  public static func newSession(endpoint: URL, body: String = defaultSessionRequestBody,
+                                httpClient: HTTPClient) async throws -> WebDriverClient
+  {
+    struct Response: Decodable {
+      let sessionId: String
     }
+    struct Request: Encodable {
+      let capabilities: [String: String] = [:]
+      let desiredCapabilities: [String: String] = [:]
+    }
+    let httpResponse = try await httpClient.post(
+      url: endpoint.appendingPathComponent("session").absoluteString,
+      body: HTTPClient.Body.string(body)
+    ).get()
+    guard let responseBody = httpResponse.body else {
+      throw WebDriverError.newSessionFailed(httpResponse)
+    }
+    let decoder = JSONDecoder()
+    let response = try decoder.decode(ValueResponse<Response>.self, from: responseBody)
+    return WebDriverClient(client: httpClient,
+                           driverEndpoint: endpoint,
+                           sessionId: response.sessionId)
+  }
 
-    private func makeSessionURL(_ components: String...) -> String {
-        var url = driverEndpoint
-            .appendingPathComponent("session")
-            .appendingPathComponent(sessionId)
-        for component in components {
-            url.appendPathComponent(component)
-        }
-        return url.absoluteString
+  private func makeSessionURL(_ components: String...) -> String {
+    var url = driverEndpoint
+      .appendingPathComponent("session")
+      .appendingPathComponent(sessionId)
+    for component in components {
+      url.appendPathComponent(component)
     }
+    return url.absoluteString
+  }
 
-    private static func makeRequestBody<R: Encodable>(_ body: R) throws -> HTTPClient.Body {
-        let encoder = JSONEncoder()
-        return try HTTPClient.Body.data(encoder.encode(body))
-    }
+  private static func makeRequestBody<R: Encodable>(_ body: R) throws -> HTTPClient.Body {
+    let encoder = JSONEncoder()
+    return try HTTPClient.Body.data(encoder.encode(body))
+  }
 
-    public func goto(url: String) async throws {
-        struct Response: Decodable {}
-        struct Request: Encodable {
-            let url: String
-        }
-        _ = try await client.post(
-            url: makeSessionURL("url"),
-            body: Self.makeRequestBody(Request(url: url))
-        )
-        .get()
+  public func goto(url: String) async throws {
+    struct Response: Decodable {}
+    struct Request: Encodable {
+      let url: String
     }
+    _ = try await client.post(
+      url: makeSessionURL("url"),
+      body: Self.makeRequestBody(Request(url: url))
+    )
+    .get()
+  }
 
-    public func closeSession() async throws {
-        _ = try await client.delete(url: makeSessionURL()).get()
-    }
+  public func closeSession() async throws {
+    _ = try await client.delete(url: makeSessionURL()).get()
+  }
 }

--- a/Sources/WebDriverClient/WebDriverClient.swift
+++ b/Sources/WebDriverClient/WebDriverClient.swift
@@ -92,7 +92,6 @@ public struct WebDriverClient {
   }
 
   public func goto(url: String) async throws {
-    struct Response: Decodable {}
     struct Request: Encodable {
       let url: String
     }

--- a/Sources/WebDriverClient/WebDriverClient.swift
+++ b/Sources/WebDriverClient/WebDriverClient.swift
@@ -1,0 +1,87 @@
+// Copyright 2022 Carton contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import AsyncHTTPClient
+
+public enum WebDriverError: Error {
+    case newSessionFailed(HTTPClient.Response)
+}
+
+public struct WebDriverClient {
+
+    let client: HTTPClient
+    let driverEndpoint: URL
+    let sessionId: String
+
+    @dynamicMemberLookup
+    struct ValueResponse<Value: Decodable>: Decodable {
+        let value: Value
+        subscript<T>(dynamicMember keyPath: KeyPath<Value, T>) -> T {
+            return self.value[keyPath: keyPath]
+        }
+    }
+
+    public static func newSession(endpoint: URL, httpClient: HTTPClient) async throws -> WebDriverClient {
+        struct Response: Decodable {
+            let sessionId: String
+        }
+        struct Request: Encodable {
+            let capabilities: [String: String] = [:]
+        }
+        let httpResponse = try await httpClient.post(
+            url: endpoint.appendingPathComponent("session").absoluteString,
+            body: makeRequestBody(Request())
+        ).get()
+        guard let responseBody = httpResponse.body else {
+            throw WebDriverError.newSessionFailed(httpResponse)
+        }
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(ValueResponse<Response>.self, from: responseBody)
+        return WebDriverClient(client: httpClient,
+                               driverEndpoint: endpoint,
+                               sessionId: response.sessionId)
+    }
+
+    private func makeSessionURL(_ components: String...) -> String {
+        var url = driverEndpoint
+            .appendingPathComponent("session")
+            .appendingPathComponent(sessionId)
+        for component in components {
+            url.appendPathComponent(component)
+        }
+        return url.absoluteString
+    }
+
+    private static func makeRequestBody<R: Encodable>(_ body: R) throws -> HTTPClient.Body {
+        let encoder = JSONEncoder()
+        return try HTTPClient.Body.data(encoder.encode(body))
+    }
+
+    public func goto(url: String) async throws {
+        struct Response: Decodable {}
+        struct Request: Encodable {
+            let url: String
+        }
+        _ = try await client.post(
+            url: makeSessionURL("url"),
+            body: Self.makeRequestBody(Request(url: url))
+        )
+        .get()
+    }
+
+    public func closeSession() async throws {
+        _ = try await client.delete(url: makeSessionURL()).get()
+    }
+}

--- a/Sources/WebDriverClient/WebDriverClient.swift
+++ b/Sources/WebDriverClient/WebDriverClient.swift
@@ -14,6 +14,7 @@
 
 import AsyncHTTPClient
 import Foundation
+import NIOFoundationCompat
 
 public enum WebDriverError: Error {
   case newSessionFailed(HTTPClient.Response)

--- a/Tests/CartonCommandTests/TestCommandTests.swift
+++ b/Tests/CartonCommandTests/TestCommandTests.swift
@@ -70,6 +70,18 @@ final class TestCommandTests: XCTestCase {
     }
   }
 
+  func testHeadlessBrowser() throws {
+    guard Process.findExecutable("safaridriver") != nil else {
+      throw XCTSkip("WebDriver is required")
+    }
+    try withFixture(Constants.testAppPackageName) { packageDirectory in
+      AssertExecuteCommand(
+        command: "carton test --environment defaultBrowser --headless",
+        cwd: packageDirectory.url
+      )
+    }
+  }
+
   // This test is prone to hanging on Linux.
   #if os(macOS)
   func testEnvironmentDefaultBrowser() throws {

--- a/Tests/WebDriverClientTests/WebDriverClientTests.swift
+++ b/Tests/WebDriverClientTests/WebDriverClientTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import WebDriverClient
+import AsyncHTTPClient
+
+final class WebDriverClientTests: XCTestCase {
+    let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+
+    override func tearDown() async throws {
+        try httpClient.syncShutdown()
+    }
+    
+    func checkRemoteURL() throws -> URL {
+        guard let value = ProcessInfo.processInfo.environment["WEBDRIVER_REMOTE_URL"] else {
+            throw XCTSkip("Skip WebDriver tests due to no WEBDRIVER_REMOTE_URL env var")
+        }
+        return try XCTUnwrap(URL(string: value), "Invalid URL string: \(value)")
+    }
+
+    func testGoto() async throws {
+        let client = try await WebDriverClient.newSession(
+            endpoint: checkRemoteURL(), httpClient: httpClient
+        )
+        try await client.goto(url: "https://example.com")
+        try await client.closeSession()
+    }
+}

--- a/Tests/WebDriverClientTests/WebDriverClientTests.swift
+++ b/Tests/WebDriverClientTests/WebDriverClientTests.swift
@@ -1,26 +1,26 @@
-import XCTest
-import WebDriverClient
 import AsyncHTTPClient
+import WebDriverClient
+import XCTest
 
 final class WebDriverClientTests: XCTestCase {
-    let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+  let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
 
-    override func tearDown() async throws {
-        try httpClient.syncShutdown()
-    }
-    
-    func checkRemoteURL() throws -> URL {
-        guard let value = ProcessInfo.processInfo.environment["WEBDRIVER_REMOTE_URL"] else {
-            throw XCTSkip("Skip WebDriver tests due to no WEBDRIVER_REMOTE_URL env var")
-        }
-        return try XCTUnwrap(URL(string: value), "Invalid URL string: \(value)")
-    }
+  override func tearDown() async throws {
+    try httpClient.syncShutdown()
+  }
 
-    func testGoto() async throws {
-        let client = try await WebDriverClient.newSession(
-            endpoint: checkRemoteURL(), httpClient: httpClient
-        )
-        try await client.goto(url: "https://example.com")
-        try await client.closeSession()
+  func checkRemoteURL() throws -> URL {
+    guard let value = ProcessInfo.processInfo.environment["WEBDRIVER_REMOTE_URL"] else {
+      throw XCTSkip("Skip WebDriver tests due to no WEBDRIVER_REMOTE_URL env var")
     }
+    return try XCTUnwrap(URL(string: value), "Invalid URL string: \(value)")
+  }
+
+  func testGoto() async throws {
+    let client = try await WebDriverClient.newSession(
+      endpoint: checkRemoteURL(), httpClient: httpClient
+    )
+    try await client.goto(url: "https://example.com")
+    try await client.closeSession()
+  }
 }

--- a/Tests/WebDriverClientTests/WebDriverClientTests.swift
+++ b/Tests/WebDriverClientTests/WebDriverClientTests.swift
@@ -1,3 +1,17 @@
+// Copyright 2022 Carton contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import AsyncHTTPClient
 import WebDriverClient
 import XCTest


### PR DESCRIPTION
## Motivation 

`carton test --environment defaultBrowser` only works on macOS or X Window systems, so tests using browser APIs cannot be run on CI easily. Add a headless test runner based on WebDriver.

## Changed

- Add `WebDriverClient` module, which is a thin client of W3C WebDriver: https://w3c.github.io/webdriver/
- Add `--headless` option to `carton test`