### PR TITLE
Revert "Use `--static-swift-stdlib` for easier distribution on Linux"

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build the project
         run: |
           swift -v
-          swift build -Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none --static-swift-stdlib
+          swift build -Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none
 
       - name: Build and install JavaScript and sanitizer resources
         run: |
@@ -62,11 +62,6 @@ jobs:
           if [ -e /home/runner/.wasmer/wasmer.sh ]; then
             source /home/runner/.wasmer/wasmer.sh
           fi
-
-          # Object files built with `--static-swift-stdlib` are not compatible with object files without
-          # `--static-swift-stdlib` because they link different libraries. And `swift test --static-swift-stdlib`
-          # doesn't work since XCTest is not built as static library and not installed `under swift_static`.
-          rm -rf .build/x86_64-unknown-linux-gnu
           swift test -Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,3 @@
-FROM swift:5.6-focal
-
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-  apt-get -q install -y \
-  build-essential \
-  libncurses5 \
-  libsqlite3-0 \
-  libsqlite3-dev \
-  libxkbcommon0 \
-  curl \
-  unzip
-
-COPY . carton/
-
-RUN cd carton && \
-  ./install_ubuntu_deps.sh && \
-  swift build -c release --static-swift-stdlib
-
 FROM ghcr.io/swiftwasm/swift:5.6-focal
 
 LABEL maintainer="SwiftWasm Maintainers <hello@swiftwasm.org>"
@@ -31,8 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
   libxkbcommon0 \
   curl unzip \
   && export WASMER_DIR=/usr/local && curl https://get.wasmer.io -sSfL | sh -s "2.2.1" && \
-  rm -r /var/lib/apt/lists/* && \
-  rm -rf /tmp/wasmer* 
+  rm -r /var/lib/apt/lists/*
 
 ENV CARTON_ROOT=/root/.carton
 ENV CARTON_DEFAULT_TOOLCHAIN=wasm-5.6.0-RELEASE
@@ -41,14 +22,19 @@ RUN mkdir -p $CARTON_ROOT/sdk && \
   mkdir -p $CARTON_ROOT/sdk/$CARTON_DEFAULT_TOOLCHAIN && \
   ln -s /usr $CARTON_ROOT/sdk/$CARTON_DEFAULT_TOOLCHAIN/usr
 
+COPY . carton/
+
 ENV NODE_VERSION=18.1.0 
 
 RUN curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
-  tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 --no-same-owner
+    tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 --no-same-owner
 
-COPY --from=0 /carton/.build/release/carton /usr/bin
-
-RUN carton --version
+RUN cd carton && \
+  ./install_ubuntu_deps.sh && \
+  swift build -c release && \
+  mv .build/release/carton /usr/bin && \
+  cd .. && \
+  rm -rf carton /tmp/wasmer*
 
 # Set the default command to run
 CMD ["carton --help"]

--- a/install_ubuntu_deps.sh
+++ b/install_ubuntu_deps.sh
@@ -3,11 +3,9 @@
 set -ex
 
 if [ -x "$(command -v sudo)" ]; then
-  sudo apt-get update -y
-  sudo apt-get install -y zlib1g-dev libsqlite3-dev libcurl4-openssl-dev
+  sudo apt-get install zlib1g-dev libsqlite3-dev
 else
-  apt-get update -y
-  apt-get install -y zlib1g-dev libsqlite3-dev libcurl4-openssl-dev
+  apt-get install zlib1g-dev libsqlite3-dev
 fi
 
 BINARYEN_VERSION=105


### PR DESCRIPTION
Reverts swiftwasm/carton#343

As reported by @kateinoigakukun:

> after adding --static-swift-stdlib, carton init and other commands started hanging.
> It seems something wrong in Foundation or global executor. The min repro for the hang is here
> https://gist.github.com/kateinoigakukun/a3ee55fa2480a46959211c53de862131
