### PR TITLE
Toolchain changes for 5.7

### DIFF
--- a/Sources/CartonCLI/Commands/Bundle.swift
+++ b/Sources/CartonCLI/Commands/Bundle.swift
@@ -146,7 +146,7 @@ struct Bundle: AsyncParsableCommand {
     wasmOutputFilePath: AbsolutePath,
     buildDirectory: AbsolutePath,
     bundleDirectory: AbsolutePath,
-    toolchain: Toolchain,
+    toolchain: SwiftToolchain.Toolchain,
     product: ProductDescription
   ) throws {
     // Rename the final binary to use a part of its hash to bust browsers and CDN caches.

--- a/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
@@ -134,7 +134,7 @@ struct BrowserTestRunner: TestRunner {
   }
 
   func run() async throws {
-    defer { try? httpClient.syncShutdown() }
+    defer { try httpClient.syncShutdown() }
     try Constants.entrypoint.check(on: localFileSystem, terminal)
     let server = try await Server(
       .init(

--- a/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
@@ -134,7 +134,7 @@ struct BrowserTestRunner: TestRunner {
   }
 
   func run() async throws {
-    defer { try httpClient.syncShutdown() }
+    defer { try? httpClient.syncShutdown() }
     try Constants.entrypoint.check(on: localFileSystem, terminal)
     let server = try await Server(
       .init(

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.7-SNAPSHOT-2022-05-19-a"
+public let defaultToolchainVersion = "wasm-5.7-SNAPSHOT-2022-07-14-a"

--- a/Sources/SwiftToolchain/Manifest.swift
+++ b/Sources/SwiftToolchain/Manifest.swift
@@ -20,9 +20,10 @@ import TSCBasic
 import Workspace
 
 extension Manifest {
-  static func from(path: AbsolutePath, swiftc: AbsolutePath, fileSystem: FileSystem, terminal: InteractiveWriter) async throws -> Manifest {
+  static func from(path: AbsolutePath, binDir: AbsolutePath, fileSystem: FileSystem, terminal: InteractiveWriter) async throws -> Manifest {
     terminal.write("\nParsing package manifest: ", inColor: .yellow)
-    let toolchain = ToolchainConfiguration(swiftCompilerPath: swiftc)
+    let destination = try Destination.hostDestination(binDir)
+    let toolchain = try UserToolchain(destination: destination)
     let loader = ManifestLoader(toolchain: toolchain)
     let observability = ObservabilitySystem { _, diagnostic in
       terminal.write("\n\(diagnostic)")

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -350,31 +350,37 @@ public final class Toolchain {
 
   private func basicBuildArguments(flavor: BuildFlavor) -> [String] {
     var builderArguments = ["--triple", "wasm32-unknown-wasi"]
+    defer {
+      builderArguments.append(contentsOf: flavor.swiftCompilerFlags.flatMap {
+        ["-Xswiftc", $0]
+      })
+    }
 
+    guard let wasmVersion = try? Version(swiftWasmVersion: version) else {
+      return builderArguments
+    }
+    
     // Versions later than 5.3.x have test discovery enabled by default and the explicit flag
     // deprecated.
-    if ["wasm-5.3.0-RELEASE", "wasm-5.3.1-RELEASE"].contains(version) {
+    if wasmVersion.major == 5, wasmVersion.minor == 3 {
       builderArguments.append("--enable-test-discovery")
     }
 
     // SwiftWasm 5.5 requires explicit linking arguments in certain configurations,
     // see https://github.com/swiftwasm/swift/issues/3891
-    if version.starts(with: "wasm-5.5") {
+    if wasmVersion.major == 5, wasmVersion.minor == 5 {
       builderArguments.append(contentsOf: ["-Xlinker", "-licuuc", "-Xlinker", "-licui18n"])
     }
 
-    // SwiftWasm 5.6 requires reactor model from updated wasi-libc when not building as a command
+    // SwiftWasm 5.6 and up requires reactor model from updated wasi-libc when not building as a command
     // see https://github.com/WebAssembly/WASI/issues/13
-    if version.starts(with: "wasm-5.6") && flavor.environment != .wasmer {
+    if wasmVersion >= Version(5, 6, 0) && flavor.environment != .wasmer {
       builderArguments.append(contentsOf: [
         "-Xswiftc", "-Xclang-linker", "-Xswiftc", "-mexec-model=reactor",
         "-Xlinker", "--export=main",
       ])
     }
 
-    builderArguments.append(contentsOf: flavor.swiftCompilerFlags.flatMap {
-      ["-Xswiftc", $0]
-    })
     return builderArguments
   }
 
@@ -403,5 +409,24 @@ extension Result where Failure == Error {
     } catch {
       self = .failure(error)
     }
+  }
+}
+
+extension Version {
+  /// Initialize a numeric version from a SwiftWasm Toolchain version string, e.g.:
+  /// "wasm-5.3.1-RELEASE", "wasm-5.7-SNAPSHOT-2022-07-14-a",
+  /// **discarding all identifiers**.
+  /// Note: input toolchain name already has "swift-" prefix stripped.
+  init(swiftWasmVersion: String) throws {
+    let prefix = "wasm-"
+    guard swiftWasmVersion.hasPrefix(prefix) else {
+      throw ToolchainError.invalidVersion(version: swiftWasmVersion)
+    }
+    var swiftWasmVersion = swiftWasmVersion
+    swiftWasmVersion.removeFirst(prefix.count)
+    
+    let version = try Version(versionString: swiftWasmVersion, usesLenientParsing: true)
+    // Strip prereleaseIdentifiers
+    self.init(version.major, version.minor, version.patch)
   }
 }

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -126,9 +126,9 @@ public final class Toolchain {
     self.fileSystem = fileSystem
     self.terminal = terminal
     if let workingDirectory = fileSystem.currentWorkingDirectory {
-      let swiftc = swiftPath.parentDirectory.appending(component: "swiftc")
+      let binDir = swiftPath.parentDirectory
       manifest = await Result {
-        try await Manifest.from(path: workingDirectory, swiftc: swiftc, fileSystem: fileSystem, terminal: terminal)
+        try await Manifest.from(path: workingDirectory, binDir: binDir, fileSystem: fileSystem, terminal: terminal)
       }
     } else {
       manifest = .failure(ToolchainError.noWorkingDirectory)

--- a/Tests/CartonTests/CartonTests.swift
+++ b/Tests/CartonTests/CartonTests.swift
@@ -15,13 +15,14 @@
 import CartonHelpers
 @testable import CartonKit
 import class Foundation.Bundle
-import SwiftToolchain
+@testable import SwiftToolchain
 import TSCBasic
+import TSCUtility
 import XCTest
 
 final class CartonTests: XCTestCase {
   /// Returns path to the built products directory.
-  var productsDirectory: URL {
+  var productsDirectory: Foundation.URL {
     #if os(macOS)
     for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
       return bundle.bundleURL.deletingLastPathComponent()
@@ -142,5 +143,21 @@ final class CartonTests: XCTestCase {
       DestinationEnvironment(userAgent: "Opera/9.30 (Nintendo Wii; U; ; 3642; en)"),
       nil
     )
+  }
+  
+  func testSwiftWasmVersionParsing() throws {
+    let v5_6 = try Version(swiftWasmVersion: "wasm-5.6.0-RELEASE")
+    XCTAssertEqual(v5_6.major, 5)
+    XCTAssertEqual(v5_6.minor, 6)
+    XCTAssertEqual(v5_6.patch, 0)
+    XCTAssert(v5_6.prereleaseIdentifiers.isEmpty)
+    XCTAssert(v5_6 >= Version(5, 6, 0))
+    
+    let v5_7_snapshot = try Version(swiftWasmVersion: "wasm-5.7-SNAPSHOT-2022-07-14-a")
+    XCTAssertEqual(v5_7_snapshot.major, 5)
+    XCTAssertEqual(v5_7_snapshot.minor, 7)
+    XCTAssertEqual(v5_7_snapshot.patch, 0)
+    XCTAssert(v5_7_snapshot.prereleaseIdentifiers.isEmpty)
+    XCTAssert(v5_7_snapshot >= Version(5, 6, 0))
   }
 }


### PR DESCRIPTION
Currently carton itself builds with (host)Swift 5.6, can build SwiftWasm projects with latest 5.7 snapshot.
Still some work needed to make carton build with (host)Swift 5.7.