### PR TITLE
Ignore force_try swift-lint rule where in defer.

### DIFF
--- a/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/BrowserTestRunner.swift
@@ -134,6 +134,7 @@ struct BrowserTestRunner: TestRunner {
   }
 
   func run() async throws {
+    // swiftlint:disable force_try
     defer { try! httpClient.syncShutdown() }
     try Constants.entrypoint.check(on: localFileSystem, terminal)
     let server = try await Server(


### PR DESCRIPTION
[Some jobs](https://github.com/swiftwasm/carton/actions/runs/3049464466/jobs/4915562336) failed because of swiftlint.
I disabled the rule for that part, is there another way?

