### PR TITLE
Fix SwiftPM dependency warning for template project

### DIFF
--- a/Sources/CartonKit/Model/Template.swift
+++ b/Sources/CartonKit/Model/Template.swift
@@ -42,7 +42,6 @@ enum TemplateError: Error {
 }
 
 struct PackageDependency: CustomStringConvertible {
-  let name: String
   let url: String
   let version: Version
 
@@ -60,7 +59,7 @@ struct PackageDependency: CustomStringConvertible {
   }
 
   var description: String {
-    #".package(name: "\#(name)", url: "\#(url)", \#(version))"#
+    #".package(url: "\#(url)", \#(version))"#
   }
 }
 
@@ -143,7 +142,6 @@ extension Templates {
         project: project,
         dependencies: [
           .init(
-            name: "JavaScriptKit",
             url: "https://github.com/swiftwasm/JavaScriptKit",
             version: .from(compatibleJSKitVersion.description)
           ),
@@ -177,7 +175,6 @@ extension Templates {
         platforms: [".macOS(.v11)", ".iOS(.v13)"],
         dependencies: [
           .init(
-            name: "Tokamak",
             url: "https://github.com/TokamakUI/Tokamak",
             version: .from("0.11.0")
           ),


### PR DESCRIPTION
In Package.swift of template project, its dependency is declared with [package(name:url:from:)](https://developer.apple.com/documentation/packagedescription/package/dependency/package(name:url:from:)) which has been already deprecated so that Xcode show warining.
<image src="https://user-images.githubusercontent.com/7476703/193413236-5325e91b-f5a2-42d7-b525-802933574e21.png" width="300" />

This PR replace the method with [package(url:from:)](https://developer.apple.com/documentation/packagedescription/package/dependency/package(url:from:)) to fix the warning.
