### PR TITLE
Allow to save .swift-version even .swift-version is missing

### DIFF
--- a/Sources/CartonCLI/Commands/SDK/Local.swift
+++ b/Sources/CartonCLI/Commands/SDK/Local.swift
@@ -27,23 +27,22 @@ struct Local: ParsableCommand {
 
   func run() throws {
     let terminal = InteractiveWriter.stdout
-
     let toolchainSystem = ToolchainSystem(fileSystem: localFileSystem)
-    guard let localVersion = try toolchainSystem.fetchLocalSwiftVersion() else {
-      terminal.logLookup("Version file is not present: ", toolchainSystem.swiftVersionPath)
-      return
-    }
-
-    guard let version = version else {
-      terminal.write("\(localVersion)", inColor: .green)
-      return
-    }
-
-    let versions = try toolchainSystem.fetchAllSwiftVersions()
-    if versions.contains(version) {
-      _ = try toolchainSystem.setLocalSwiftVersion(version)
+    
+    if let version = version {
+      let versions = try toolchainSystem.fetchAllSwiftVersions()
+      if versions.contains(version) {
+        _ = try toolchainSystem.setLocalSwiftVersion(version)
+      } else {
+        terminal.write("The version \(version) hasn't been installed!", inColor: .red)
+      }
     } else {
-      terminal.write("The version \(version) hasn't been installed!", inColor: .red)
+      let localVersion = try toolchainSystem.fetchLocalSwiftVersion()
+      if let localVersion = localVersion {
+        terminal.write("\(localVersion)", inColor: .green)
+      } else {
+        terminal.logLookup("Version file is not present: ", toolchainSystem.swiftVersionPath)
+      }
     }
   }
 }


### PR DESCRIPTION
When we have a project which does not contain .swift-version, `carton sdk local wasm-5.7.1-RELEASE` just claims that .swift-version does not exist, even though it is a valid toolchain version. I think it is inconvenient.

This PR makes to allow saving the local toolchain version even if the .swift-version is not present. 