### PR TITLE
Fix carton sdk install on linux(aarch64)

### DIFF
--- a/Sources/SwiftToolchain/ToolchainManagement.swift
+++ b/Sources/SwiftToolchain/ToolchainManagement.swift
@@ -170,7 +170,11 @@ public class ToolchainSystem {
     #if arch(x86_64)
     let archSuffix = "x86_64"
     #elseif arch(arm64)
-    let archSuffix = "arm64"
+      #if os(macOS)
+      let archSuffix = "arm64"
+      #elseif os(Linux)
+      let archSuffix = "aarch64"
+      #endif
     #endif
 
     #if os(macOS)


### PR DESCRIPTION
On linux for aarch64 architecture, `carton sdk install` command fails with the following error.

```
# carton sdk install wasm-5.7.1-RELEASE
- checking Swift compiler path: /root/.carton/sdk/wasm-5.7.1-RELEASE/usr/bin/swift
- checking Swift compiler path: /root/.swiftenv/versions/wasm-5.7.1-RELEASE/usr/bin/swift
Fetching release assets from https://api.github.com/repos/swiftwasm/swift/releases/tags/swift-wasm-5.7.1-RELEASE
Response contained body, parsing it now...
Response succesfully parsed, choosing from this number of assets: 6
The Swift version wasm-5.7.1-RELEASE was not found
Error: Invalid version wasm-5.7.1-RELEASE
```

The reason seemed to be a wrong download URL for that. 

( `carton sdk install` searches the download URL from https://api.github.com/repos/swiftwasm/swift/releases/tags/swift-wasm-5.7.1-RELEASE )
