### PR TITLE
Added support swift 5.8

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -105,16 +105,16 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
-          "version": "1.1.7"
+          "revision": "75ec60b8b4cc0f085c3ac414f3dca5625fa3588e",
+          "version": "2.2.4"
         }
       },
       {
         "package": "swift-driver",
         "repositoryURL": "https://github.com/apple/swift-driver.git",
         "state": {
-          "branch": "release/5.7",
-          "revision": "719426df790661020de657bf38beb2a8b1de5ad3",
+          "branch": "release/5.8",
+          "revision": "7cfe0c0b6e6297efe88a3ce34e6138ee7eda969e",
           "version": null
         }
       },
@@ -122,8 +122,8 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "release/5.7",
-          "revision": "564424db5fdb62dcb5d863bdf7212500ef03a87b",
+          "branch": "release/5.8",
+          "revision": "dccfc2e127a34b89a849407594cf2d604b598ba9",
           "version": null
         }
       },
@@ -203,8 +203,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "release/5.7",
-          "revision": "63c14b84dc12c943a9d4c102648b7617d8b92f67",
+          "branch": "release/5.8",
+          "revision": "f708879c811fe0bdd51e5e560f2b091af1090102",
           "version": null
         }
       },
@@ -221,8 +221,8 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "release/5.7",
-          "revision": "184eba382f6abbb362ffc02942d790ff35019ad4",
+          "branch": "release/5.8",
+          "revision": "ac4871e01ef338cb95b5d28328cab0ec1dfae935",
           "version": null
         }
       },
@@ -258,8 +258,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
+          "revision": "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
+          "version": "5.0.5"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -27,14 +27,14 @@ let package = Package(
     .package(
       name: "SwiftPM",
       url: "https://github.com/apple/swift-package-manager.git",
-      .branch("release/5.7")
+      .branch("release/5.8")
     ),
     .package(
       url: "https://github.com/apple/swift-tools-support-core.git",
-      .branch("release/5.7")
+      .branch("release/5.8")
     ),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.57.1"),
-    .package(url: "https://github.com/apple/swift-crypto.git", from: "1.1.0"),
+    .package(url: "https://github.com/apple/swift-crypto.git", from: "2.2.3"),
     .package(url: "https://github.com/JohnSundell/Splash.git", from: "0.16.0"),
     .package(
       url: "https://github.com/swiftwasm/WasmTransformer",

--- a/Sources/CartonCLI/Commands/Bundle.swift
+++ b/Sources/CartonCLI/Commands/Bundle.swift
@@ -156,7 +156,7 @@ struct Bundle: AsyncParsableCommand {
     try localFileSystem.move(from: wasmOutputFilePath, to: mainModulePath)
 
     // Copy the bundle entrypoint, point to the binary, and give it a cachebuster name.
-    let (_, _, entrypointPath) = dependency.paths(on: localFileSystem)
+    let (_, _, entrypointPath) = try dependency.paths(on: localFileSystem)
     let entrypoint = try ByteString(
       encodingAsUTF8: localFileSystem.readFileContents(entrypointPath)
         .description

--- a/Sources/CartonCLI/Commands/SDK/Local.swift
+++ b/Sources/CartonCLI/Commands/SDK/Local.swift
@@ -27,7 +27,7 @@ struct Local: ParsableCommand {
 
   func run() throws {
     let terminal = InteractiveWriter.stdout
-    let toolchainSystem = ToolchainSystem(fileSystem: localFileSystem)
+    let toolchainSystem = try ToolchainSystem(fileSystem: localFileSystem)
     
     if let version = version {
       let versions = try toolchainSystem.fetchAllSwiftVersions()

--- a/Sources/CartonCLI/Commands/SDK/Versions.swift
+++ b/Sources/CartonCLI/Commands/SDK/Versions.swift
@@ -25,7 +25,7 @@ struct Versions: ParsableCommand {
   func run() throws {
     let terminal = InteractiveWriter.stdout
 
-    let toolchainSystem = ToolchainSystem(fileSystem: localFileSystem)
+    let toolchainSystem = try ToolchainSystem(fileSystem: localFileSystem)
     let versions = try toolchainSystem.fetchAllSwiftVersions()
     let localVersion = try toolchainSystem.fetchLocalSwiftVersion()
     if versions.count > 0 {

--- a/Sources/CartonCLI/Commands/TestRunners/NodeTestRunner.swift
+++ b/Sources/CartonCLI/Commands/TestRunners/NodeTestRunner.swift
@@ -32,7 +32,7 @@ struct NodeTestRunner: TestRunner {
     terminal.write("\nRunning the test bundle with Node.js:\n", inColor: .yellow)
 
     try Constants.entrypoint.check(on: localFileSystem, terminal)
-    let (_, _, entrypointPath) = Constants.entrypoint.paths(on: localFileSystem)
+    let (_, _, entrypointPath) = try Constants.entrypoint.paths(on: localFileSystem)
 
     // Allow Node.js to resolve modules from resource directories by making them relative to the entrypoint path.
     let buildDirectory = testFilePath.parentDirectory

--- a/Sources/CartonKit/Model/Entrypoint.swift
+++ b/Sources/CartonKit/Model/Entrypoint.swift
@@ -33,14 +33,14 @@ public struct Entrypoint {
   public func paths(
     on fileSystem: FileSystem
     // swiftlint:disable:next large_tuple
-  ) -> (cartonDir: AbsolutePath, staticDir: AbsolutePath, filePath: AbsolutePath) {
-    let cartonDir = fileSystem.homeDirectory.appending(component: ".carton")
+  ) throws -> (cartonDir: AbsolutePath, staticDir: AbsolutePath, filePath: AbsolutePath) {
+    let cartonDir = try fileSystem.homeDirectory.appending(component: ".carton")
     let staticDir = cartonDir.appending(component: "static")
     return (cartonDir, staticDir, staticDir.appending(component: fileName))
   }
 
   public func check(on fileSystem: FileSystem, _ terminal: InteractiveWriter) throws {
-    let (cartonDir, staticDir, filePath) = paths(on: fileSystem)
+    let (cartonDir, staticDir, filePath) = try paths(on: fileSystem)
 
     // If hash check fails, download the `static.zip` archive and unpack it
     if try !fileSystem.exists(filePath) || SHA256().hash(

--- a/Sources/SwiftToolchain/Builder.swift
+++ b/Sources/SwiftToolchain/Builder.swift
@@ -109,7 +109,7 @@ public final class Builder {
       return try await buildWithoutSanitizing(builderArguments: arguments)
     case .stackOverflow:
       let sanitizerFile =
-        fileSystem.homeDirectory.appending(components: ".carton", "static", "so_sanitizer.wasm")
+        try fileSystem.homeDirectory.appending(components: ".carton", "static", "so_sanitizer.wasm")
 
       var modifiedArguments = arguments
       modifiedArguments.append(contentsOf: [

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -119,7 +119,7 @@ public final class Toolchain {
     _ fileSystem: FileSystem,
     _ terminal: InteractiveWriter
   ) async throws {
-    let toolchainSystem = ToolchainSystem(fileSystem: fileSystem)
+    let toolchainSystem = try ToolchainSystem(fileSystem: fileSystem)
     let (swiftPath, version) = try await toolchainSystem.inferSwiftPath(from: versionSpec, terminal)
     self.swiftPath = swiftPath
     self.version = version

--- a/Sources/SwiftToolchain/ToolchainManagement.swift
+++ b/Sources/SwiftToolchain/ToolchainManagement.swift
@@ -46,7 +46,7 @@ public class ToolchainSystem {
   let cartonToolchainResolver: CartonToolchainResolver
   let resolvers: [ToolchainResolver]
 
-  public init(fileSystem: FileSystem) {
+  public init(fileSystem: FileSystem) throws {
     self.fileSystem = fileSystem
 
     let userLibraryPath = NSSearchPathForDirectoriesInDomains(
@@ -69,10 +69,10 @@ public class ToolchainSystem {
       userXCToolchainResolver, rootXCToolchainResolver,
     ].compactMap { $0 }
 
-    cartonToolchainResolver = CartonToolchainResolver(fileSystem: fileSystem)
+    cartonToolchainResolver = try CartonToolchainResolver(fileSystem: fileSystem)
     resolvers = [
       cartonToolchainResolver,
-      SwiftEnvToolchainResolver(fileSystem: fileSystem),
+      try SwiftEnvToolchainResolver(fileSystem: fileSystem),
     ] + xctoolchainResolvers
   }
 

--- a/Sources/SwiftToolchain/ToolchainResolver.swift
+++ b/Sources/SwiftToolchain/ToolchainResolver.swift
@@ -47,8 +47,8 @@ final class SwiftEnvToolchainResolver: ToolchainResolver {
   let versionsPath: AbsolutePath
   let fileSystem: FileSystem
 
-  init(fileSystem: FileSystem) {
-    versionsPath = fileSystem.homeDirectory.appending(components: ".swiftenv", "versions")
+  init(fileSystem: FileSystem) throws {
+    versionsPath =  try fileSystem.homeDirectory.appending(components: ".swiftenv", "versions")
     self.fileSystem = fileSystem
   }
 
@@ -68,8 +68,8 @@ final class CartonToolchainResolver: ToolchainResolver {
   let cartonSDKPath: AbsolutePath
   let fileSystem: FileSystem
 
-  init(fileSystem: FileSystem) {
-    cartonSDKPath = fileSystem.homeDirectory.appending(components: ".carton", "sdk")
+  init(fileSystem: FileSystem) throws {
+    cartonSDKPath = try fileSystem.homeDirectory.appending(components: ".carton", "sdk")
     self.fileSystem = fileSystem
   }
 

--- a/Sources/carton-release/HashArchive.swift
+++ b/Sources/carton-release/HashArchive.swift
@@ -39,7 +39,8 @@ struct HashArchive: AsyncParsableCommand {
     let terminal = InteractiveWriter.stdout
     let cwd = localFileSystem.currentWorkingDirectory!
     let staticPath = AbsolutePath(cwd, "static")
-    let dotFilesStaticPath = localFileSystem.homeDirectory.appending(
+    
+    let dotFilesStaticPath = try localFileSystem.homeDirectory.appending(
       components: ".carton",
       "static"
     )


### PR DESCRIPTION
currently,  the main branch doesn't support swift 5.8. 
My pull request changed the versions of the dependencies to add support swift 8.5.

when running `swift build -c release` with swift 5.8, you will get the errors:
```
/app/.build/checkouts/swift-tools-support-core/Sources/TSCclibc/process.c:10:12: error: call to undeclared function 'posix_spawn_file_actions_addchdir_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    return posix_spawn_file_actions_addchdir_np(file_actions, path);
           ^
/app/.build/checkouts/swift-tools-support-core/Sources/TSCclibc/process.c:10:12: note: did you mean 'SPM_posix_spawn_file_actions_addchdir_np'?
/app/.build/checkouts/swift-tools-support-core/Sources/TSCclibc/process.c:7:5: note: 'SPM_posix_spawn_file_actions_addchdir_np' declared here
int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restrict file_actions, const char *restrict path) {
    ^
1 error generated.
remark: Incremental compilation has been disabled: it is not compatible with whole module optimization
[8/882] Compiling a_object.c
```