### PR TITLE
Support jammy and amazonlinux2 for toolchain install

### DIFF
--- a/Sources/SwiftToolchain/ToolchainManagement.swift
+++ b/Sources/SwiftToolchain/ToolchainManagement.swift
@@ -195,6 +195,8 @@ public class ToolchainSystem {
         ubuntuSuffix = "ubuntu18.04"
       } else if releaseData.contains("DISTRIB_RELEASE=20.04") {
         ubuntuSuffix = "ubuntu20.04"
+      } else if releaseData.contains("DISTRIB_RELEASE=22.04") {
+        ubuntuSuffix = "ubuntu22.04"
       } else {
         throw ToolchainError.unsupportedOperatingSystem
       }

--- a/Sources/SwiftToolchain/ToolchainManagement.swift
+++ b/Sources/SwiftToolchain/ToolchainManagement.swift
@@ -184,24 +184,7 @@ public class ToolchainSystem {
     #if os(macOS)
       let platformSuffixes = ["osx", "catalina", "macos"]
     #elseif os(Linux)
-      let releaseFile = AbsolutePath("/etc").appending(component: "lsb-release")
-      guard fileSystem.isFile(releaseFile) else {
-        throw ToolchainError.unsupportedOperatingSystem
-      }
-
-      let releaseData = try fileSystem.readFileContents(releaseFile).description
-      let ubuntuSuffix: String
-      if releaseData.contains("DISTRIB_RELEASE=18.04") {
-        ubuntuSuffix = "ubuntu18.04"
-      } else if releaseData.contains("DISTRIB_RELEASE=20.04") {
-        ubuntuSuffix = "ubuntu20.04"
-      } else if releaseData.contains("DISTRIB_RELEASE=22.04") {
-        ubuntuSuffix = "ubuntu22.04"
-      } else {
-        throw ToolchainError.unsupportedOperatingSystem
-      }
-
-      let platformSuffixes = ["linux", ubuntuSuffix]
+      let platformSuffixes = ["linux", try self.inferLinuxDistributionSuffix()]
     #endif
 
     terminal.logLookup(
@@ -212,6 +195,28 @@ public class ToolchainSystem {
     return release.assets.map(\.url).filter { url in
       nameSuffixes.contains { url.absoluteString.contains($0) }
     }.first
+  }
+
+  private func inferLinuxDistributionSuffix() throws -> String {
+    guard let releaseFile = [
+      AbsolutePath.root.appending(components: "etc", "lsb-release"),
+      AbsolutePath.root.appending(components: "etc", "os-release"),
+    ].first(where: fileSystem.isFile) else {
+      throw ToolchainError.unsupportedOperatingSystem
+    }
+
+    let releaseData = try fileSystem.readFileContents(releaseFile).description
+    if releaseData.contains("DISTRIB_RELEASE=18.04") {
+      return "ubuntu18.04"
+    } else if releaseData.contains("DISTRIB_RELEASE=20.04") {
+      return "ubuntu20.04"
+    } else if releaseData.contains("DISTRIB_RELEASE=22.04") {
+      return "ubuntu22.04"
+    } else if releaseData.contains(#"PRETTY_NAME="Amazon Linux 2""#) {
+      return "amazonlinux2"
+    } else {
+      throw ToolchainError.unsupportedOperatingSystem
+    }
   }
 
   /** Infer `swift` binary path matching a given version if any is present, or infer the


### PR DESCRIPTION
Close https://github.com/swiftwasm/carton/issues/394

Manually tested on amazonlinu2 and jammy

```
$ docker run -v $PWD:$PWD -w $PWD --rm -it swift:5.7-amazonlinux2 bash
# yum install sqlite-devel -y
# swift build --scratch-path .build/amazonlinux2
# .build/amazonlinux2/debug/carton sdk install
- checking Swift compiler path: /root/.carton/sdk/wasm-5.7.1-RELEASE/usr/bin/swift
- checking Swift compiler path: /root/.swiftenv/versions/wasm-5.7.1-RELEASE/usr/bin/swift
Fetching release assets from https://api.github.com/repos/swiftwasm/swift/releases/tags/swift-wasm-5.7.1-RELEASE
Response contained body, parsing it now...
Response succesfully parsed, choosing from this number of assets: 6
Local installation of Swift version wasm-5.7.1-RELEASE not found
Swift toolchain/SDK download URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.7.1-RELEASE/swift-wasm-5.7.1-RELEASE-amazonlinux2_x86_64.tar.gz
Archive size is 860 MB
                                                                                                        Downloading the archive
99% [============================================Download completed successfully=======================================================================================================================================---]
Unpacking the archive: tar xzf /root/.carton/sdk/wasm-5.7.1-RELEASE.gz --strip-components=1 --directory /root/.carton/sdk/wasm-5.7.1-RELEASE
- checking Swift compiler path: /root/.carton/sdk/wasm-5.7.1-RELEASE/usr/bin/swift
Inferring basic settings...
- swift executable: /root/.carton/sdk/wasm-5.7.1-RELEASE/usr/bin/swift
SwiftWasm Swift version 5.7.1 (swiftlang-5.7.1)
Target: x86_64-unknown-linux-gnu

Parsing package manifest:
[debug]: evaluating manifest for 'carton' v. unknown
SDK successfully installed!
```