### PR TITLE
Swift 5.9 toolchain & macOS Sonoma beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.0 (5 Aug 2023)
+
+This release adds SwiftWasm 5.9 toolchain support.
+
 # 0.19.1 (9 May 2023)
 
 This release fixes the wrong toolchain version installed in docker image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/swiftwasm/swift:5.8-focal
+FROM ghcr.io/swiftwasm/swift:latest
 
 LABEL maintainer="SwiftWasm Maintainers <hello@swiftwasm.org>"
 LABEL Description="Carton is a watcher, bundler, and test runner for your SwiftWasm apps"
@@ -16,7 +16,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
   rm -r /var/lib/apt/lists/*
 
 ENV CARTON_ROOT=/root/.carton
-ENV CARTON_DEFAULT_TOOLCHAIN=wasm-5.8.0-RELEASE
+ENV CARTON_DEFAULT_TOOLCHAIN=wasm-5.9-SNAPSHOT-2023-08-01-a
 
 RUN mkdir -p $CARTON_ROOT/sdk && \
   mkdir -p $CARTON_ROOT/sdk/$CARTON_DEFAULT_TOOLCHAIN && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/swiftwasm/swift:latest
+FROM ghcr.io/swiftwasm/swift:5.9-focal
 
 LABEL maintainer="SwiftWasm Maintainers <hello@swiftwasm.org>"
 LABEL Description="Carton is a watcher, bundler, and test runner for your SwiftWasm apps"
@@ -16,7 +16,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
   rm -r /var/lib/apt/lists/*
 
 ENV CARTON_ROOT=/root/.carton
-ENV CARTON_DEFAULT_TOOLCHAIN=wasm-5.9-SNAPSHOT-2023-08-01-a
+ENV CARTON_DEFAULT_TOOLCHAIN=wasm-5.9.0-RELEASE
 
 RUN mkdir -p $CARTON_ROOT/sdk && \
   mkdir -p $CARTON_ROOT/sdk/$CARTON_DEFAULT_TOOLCHAIN && \

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,17 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
+          "revision": "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
+          "version": "1.2.2"
+        }
+      },
+      {
+        "package": "swift-asn1",
+        "repositoryURL": "https://github.com/apple/swift-asn1.git",
+        "state": {
+          "branch": null,
+          "revision": "805deae27a7506dcad043604c00a9dc52d465dcb",
+          "version": "0.7.0"
         }
       },
       {
@@ -92,6 +101,15 @@
         }
       },
       {
+        "package": "swift-certificates",
+        "repositoryURL": "https://github.com/apple/swift-certificates.git",
+        "state": {
+          "branch": null,
+          "revision": "35a7df2d9d71c401a47de9be2e3de629a01370c2",
+          "version": "0.4.1"
+        }
+      },
+      {
         "package": "swift-collections",
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
@@ -105,16 +123,16 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "75ec60b8b4cc0f085c3ac414f3dca5625fa3588e",
-          "version": "2.2.4"
+          "revision": "33a20e650c33f6d72d822d558333f2085effa3dc",
+          "version": "2.5.0"
         }
       },
       {
         "package": "swift-driver",
         "repositoryURL": "https://github.com/apple/swift-driver.git",
         "state": {
-          "branch": "release/5.8",
-          "revision": "7cfe0c0b6e6297efe88a3ce34e6138ee7eda969e",
+          "branch": "release/5.9",
+          "revision": "e7b2840dbfb06007874099c6f71db6b46a3daaa1",
           "version": null
         }
       },
@@ -122,8 +140,8 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "release/5.8",
-          "revision": "dccfc2e127a34b89a849407594cf2d604b598ba9",
+          "branch": "release/5.9",
+          "revision": "d73a305d6e5a82e4bf3bf1727da3d1376e87efab",
           "version": null
         }
       },
@@ -203,8 +221,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "release/5.8",
-          "revision": "fe383ccb099ff65ca1403137e7383aedaf99af87",
+          "branch": "release/5.9",
+          "revision": "0479d07cb08310224e68f80d6365982d90cc313e",
           "version": null
         }
       },
@@ -221,8 +239,8 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "release/5.8",
-          "revision": "ac4871e01ef338cb95b5d28328cab0ec1dfae935",
+          "branch": "release/5.9",
+          "revision": "279be8ac3fe7829cc15e93693c45931a1bf7f112",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -25,13 +25,12 @@ let package = Package(
     ),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.34.0"),
     .package(
-      name: "SwiftPM",
       url: "https://github.com/apple/swift-package-manager.git",
-      .branch("release/5.9")
+      branch: "release/5.9"
     ),
     .package(
       url: "https://github.com/apple/swift-tools-support-core.git",
-      .branch("release/5.9")
+      branch: "release/5.9"
     ),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.57.1"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "2.2.0"),
@@ -71,7 +70,7 @@ let package = Package(
       dependencies: [
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "NIOFoundationCompat", package: "swift-nio"),
-        .product(name: "SwiftPMDataModel-auto", package: "SwiftPM"),
+        .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
         "CartonHelpers",
         "WasmTransformer",
       ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,17 +21,17 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
-      .upToNextMinor(from: "1.0.3")
+      .upToNextMinor(from: "1.2.2")
     ),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.34.0"),
     .package(
       name: "SwiftPM",
       url: "https://github.com/apple/swift-package-manager.git",
-      .branch("release/5.8")
+      .branch("release/5.9")
     ),
     .package(
       url: "https://github.com/apple/swift-tools-support-core.git",
-      .branch("release/5.8")
+      .branch("release/5.9")
     ),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.57.1"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "2.2.0"),

--- a/Sources/CartonHelpers/Async.swift
+++ b/Sources/CartonHelpers/Async.swift
@@ -29,10 +29,6 @@ extension Sequence {
 }
 
 /// A type that can be executed as part of a nested tree of commands.
-public protocol AsyncParsableCommand: ParsableCommand {
-  mutating func run() async throws
-}
-
 extension AsyncParsableCommand {
   public mutating func run() throws {
     throw CleanExit.helpRequest(self)

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.8.0-RELEASE"
+public let defaultToolchainVersion = "wasm-5.9-SNAPSHOT-2023-08-01-a"

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let defaultToolchainVersion = "wasm-5.9-SNAPSHOT-2023-08-01-a"
+public let defaultToolchainVersion = "wasm-5.9.0-RELEASE"

--- a/Sources/CartonHelpers/Version.swift
+++ b/Sources/CartonHelpers/Version.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let cartonVersion = "0.19.0"
+public let cartonVersion = "0.20.0"

--- a/Sources/CartonKit/Model/Template.swift
+++ b/Sources/CartonKit/Model/Template.swift
@@ -92,7 +92,7 @@ extension Template {
   ) throws {
     try fileSystem.writeFileContents(project.path.appending(component: "Package.swift")) {
       var content = """
-        // swift-tools-version:5.8
+        // swift-tools-version:5.9
         import PackageDescription
         let package = Package(
             name: "\(project.name)",\n

--- a/Sources/SwiftToolchain/Toolchain.swift
+++ b/Sources/SwiftToolchain/Toolchain.swift
@@ -19,7 +19,7 @@ import TSCBasic
 import TSCUtility
 import WasmTransformer
 
-public let compatibleJSKitVersion = Version(0, 15, 0)
+public let compatibleJSKitVersion = Version(0, 18, 0)
 
 enum ToolchainError: Error, CustomStringConvertible {
   case directoryDoesNotExist(AbsolutePath)
@@ -212,7 +212,7 @@ public final class Toolchain {
         switch target.type {
         case .regular, .executable:
           return RelativePath("Sources").appending(component: target.name).pathString
-        case .test, .system, .binary, .plugin:
+        case .test, .system, .binary, .macro, .plugin:
           return nil
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carton",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "carton",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@wasmer/wasi": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carton",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "📦 Watcher, bundler, and test runner for your SwiftWasm apps ",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This release adds SwiftWasm 5.9 toolchain support, which includes usability with macOS Sonoma beta.

```swift
- checking Swift compiler path: /Users/furby/.carton/sdk/wasm-5.9-SNAPSHOT-2023-08-01-a/usr/bin/swift
- checking Swift compiler path: /Users/furby/.swiftenv/versions/wasm-5.9-SNAPSHOT-2023-08-01-a/usr/bin/swift
- checking Swift compiler path: /Users/furby/Library/Developer/Toolchains/swift-wasm-5.9-SNAPSHOT-2023-08-01-a.xctoolchain/usr/bin/swift
Inferring basic settings...
- swift executable: /Users/furby/Library/Developer/Toolchains/swift-wasm-5.9-SNAPSHOT-2023-08-01-a.xctoolchain/usr/bin/swift
SwiftWasm Swift version 5.9-dev (LLVM 8250a14f5d3ef6a, Swift 57acd8f2a758d01)
Target: arm64-apple-darwin23.0.0

Parsing package manifest:
[debug]: evaluating manifest for 'cosmicportal' v. unknown- development binary to serve: /Users/furby/dev/Atmos/CosmicPortal/.build/wasm32-unknown-wasi/debug/CosmicPortal.wasm

Building the project before spinning up a server...
Compiling...
/Users/furby/Library/Developer/Toolchains/swift-wasm-5.9-SNAPSHOT-2023-08-01-a.xctoolchain/usr/bin/swift build -c debug --product CosmicPortal --triple wasm32-unknown-wasi -Xswiftc -Xclang-linker -Xswiftc -mexec-model=reactor -Xlinker --export=main -Xlinker /Users/furby/.carton/static/so_sanitizer.wasm -Xlinker --stack-first[0/1] Planning build
Building for debugging...
[0/1] Linking CosmicPortal.wasm
Build complete! (3.97s)


`swift` process finished successfully
`swift build` completed in 4.22 seconds
Binary transformation for Safari compatibility completed in 0.34 seconds
```