### PR TITLE
Update CI Action

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,16 +14,13 @@ jobs:
           - os: macos-12
             swift_version: 5.7
             xcode: /Applications/Xcode_14.0.app/Contents/Developer
-          - os: macos-12
-            swift_version: 5.6
-            xcode: /Applications/Xcode_13.4.app/Contents/Developer
-          - os: macos-11
-            swift_version: 5.5
-            xcode: /Applications/Xcode_13.2.1.app/Contents/Developer
-          - os: ubuntu-20.04
-            swift_version: 5.6
+          - os: macos-13
+            swift_version: 5.8
+            xcode: /Applications/Xcode_14.3.app/Contents/Developer
           - os: ubuntu-20.04
             swift_version: 5.7
+          - os: ubuntu-20.04
+            swift_version: 5.8
     name: Build on ${{ matrix.os }} with Swift ${{ matrix.swift_version }}
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
#402 will make 5.7 the minimum tools version. 
We need to move CI versions up in order for checks to pass.

- [x] The following required checks no longer exist and need to removed in repository settings:
- Build on macos-11 with Swift 5.5
- Build on macos-12 with Swift 5.6
- Build on ubuntu-20.04 with Swift 5.6 