### PR TITLE
Add linux install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To download carton and install it, run the following in your terminal, then foll
 Overall, this script ensures that Carton is installed or updated to the latest release on your system, making it ready for use.
 
 ```
-curl -sSL https://example.com/path/to/your/carton-install.sh | bash
+curl -sSL https://github.com/swiftwasm/carton/blob/main/carton-install.sh | bash
 ```
 
 ## Diocker

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ development workflow such as toolchain and SDK installations.
 
 ### Installation
 
+## MacOS
+
 On macOS `carton` can be installed with [Homebrew](https://brew.sh/). Make sure you have Homebrew
 installed and then run:
 
@@ -40,17 +42,22 @@ brew install swiftwasm/tap/carton
 > If you can't install the latest carton via `brew upgrade swiftwasm/tap/carton`, please try `rm -rf $(brew --prefix)/Library/Taps/swiftwasm/homebrew-tap/ && brew tap swiftwasm/tap` and retry again. The `master` branch was renamed to `main`, so you need to update your local tap repo.
 
 
+## Linux
+
+To download carton and install it, run the following in your terminal, then follow the on-screen instructions.
+Overall, this script ensures that Carton is installed or updated to the latest release on your system, making it ready for use.
+
+```
+curl -sSL https://example.com/path/to/your/carton-install.sh | bash
+```
+
+## Diocker
+
 `carton` is also available as a Docker image for Linux. You can pull it with this command:
 
 ```
 docker pull ghcr.io/swiftwasm/carton:latest
 ```
-
-If Docker images are not suitable for you, you'll have to build `carton` from sources on Ubuntu.
-Clone the repository and run `./install_ubuntu_deps.sh` in the root directory of the clone. After
-that completes successfully, run `swift build -c release`, the `carton` binary will be located in
-the `.build/release` directory after that. Unfortunately, other Linux distributions are currently
-not supported.
 
 ### Version compatibility
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To download carton and install it, run the following in your terminal, then foll
 Overall, this script ensures that Carton is installed or updated to the latest release on your system, making it ready for use.
 
 ```
-curl -sSL https://github.com/swiftwasm/carton/blob/main/carton-install.sh | bash
+curl -sSL https://raw.githubusercontent.com/swiftwasm/carton/main/carton-install.sh | bash
 ```
 
 ## Diocker

--- a/carton-install.sh
+++ b/carton-install.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Define the destination directory
+DEST="/usr/local/bin/carton"
+
+# Function to clean up files
+cleanup() {
+  # Clean up: Remove unnecessary files and the cloned repository
+  cd ..
+  rm -rf carton
+}
+
+# Check if the 'swift' command is available
+if ! command -v swift &> /dev/null; then
+  echo "Swift is not installed. Installing Swift..."
+  
+  # Install Swift using swiftly-install.sh
+  curl -L https://swift-server.github.io/swiftly/swiftly-install.sh | bash
+  swiftly install latest
+
+  # Check if Swift installation was successful
+  if ! command -v swift &> /dev/null; then
+    echo "Failed to install Swift. Please check the installation and try again."
+    cleanup
+    exit 1
+  fi
+fi
+
+# Clone the Carton repository
+git clone https://github.com/swiftwasm/carton.git
+cd carton
+
+# Find the latest release tag
+latest_tag=$(git describe --tags $(git rev-list --tags --max-count=1))
+
+# Checkout the latest release tag
+git checkout $latest_tag
+
+# Install dependencies
+./install_ubuntu_deps.sh
+
+# Build Carton
+swift build -c release
+
+# Check if the build was successful
+if [ $? -eq 0 ]; then
+  # Remove the old Carton binary if it exists
+  if [ -f $DEST ]; then
+    sudo rm $DEST
+  fi
+
+  # Move the binary to the destination
+  sudo mv .build/release/carton $DEST
+
+  # Set the correct permissions
+  sudo chmod 755 $DEST
+
+  echo "Carton has been successfully built and updated to the newest release ($latest_tag) at $DEST."
+
+else
+  echo "Carton build failed. Please check the dependencies and try again."
+fi
+
+# Clean up in both success and failure cases
+cleanup

--- a/carton-install.sh
+++ b/carton-install.sh
@@ -11,7 +11,7 @@ cleanup() {
 }
 
 # Check if the 'swift' command is available
-if ! command -v swift &> /dev/null; then
+if [ ! -f "$HOME/.local/bin/swift" ]; then
   echo "Swift is not installed. Installing Swift..."
   
   # Install Swift using swiftly-install.sh
@@ -19,7 +19,7 @@ if ! command -v swift &> /dev/null; then
   swiftly install latest
 
   # Check if Swift installation was successful
-  if ! command -v swift &> /dev/null; then
+if [ ! -f "$HOME/.local/bin/swift" ]; then
     echo "Failed to install Swift. Please check the installation and try again."
     cleanup
     exit 1


### PR DESCRIPTION
**1. Add linux install  bash script
2. Update readme**  

This Bash script automates the installation and update process for the "Carton" tool. 

1. Defines the destination directory for the Carton binary.
2. Checks if the 'swift' command is available, and if not, installs Swift.
3. Clones the Carton repository from GitHub.
4. Determines the latest release tag and checks out that release.
5. Installs necessary dependencies for Carton on an Ubuntu system.
6. Builds the Carton tool in release mode.
7. If the build is successful, it updates the Carton binary in the specified destination directory.
8. Cleans up temporary files and the cloned repository, regardless of success or failure.

Overall, this script ensures that Carton is installed or updated to the latest release on your system, making it ready for use in Swift WebAssembly development.


