### PR TITLE
`CartonFrontend dev` の watch 機能をオプトインにして、コマンド単体で利用可能にする

### DIFF
--- a/Sources/CartonCLI/Commands/Dev.swift
+++ b/Sources/CartonCLI/Commands/Dev.swift
@@ -100,9 +100,6 @@ struct Dev: AsyncParsableCommand {
     if !verbose {
       terminal.revertCursorAndClear()
     }
-    terminal.write("\nWatching these directories for changes:\n", inColor: .green)
-    paths.forEach { terminal.logLookup("", $0) }
-    terminal.write("\n")
 
     let server = try await Server(
       .init(

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -165,6 +165,12 @@ public actor Server {
     }
 
     if !builder.pathsToWatch.isEmpty {
+      let terminal = configuration.terminal
+
+      terminal.write("\nWatching these directories for changes:\n", inColor: .green)
+      builder.pathsToWatch.forEach { terminal.logLookup("", $0) }
+      terminal.write("\n")
+
       watcher = FSWatch(paths: builder.pathsToWatch, latency: 0.1) { [weak self] changes in
         guard let self = self, !changes.isEmpty else { return }
         Task { try await self.onChange(changes, configuration) }


### PR DESCRIPTION
# 課題

現状、CartonFrontend devコマンドを単体で使う事ができません。
devコマンドのwatch機能が、devプラグインから呼び出されることに依存しているからです。

具体的には、devコマンドが変更検知をしてリビルドをする際には、
devプラグインが用意した名前付きパイプを使って依頼するからです。

# 提案

しかし、 devコマンドが単体で使えると便利です。
devコマンドの サーバ機能の動作だけを単体テストしやすくなるからです。

そこで、devコマンドにwatch対象を指定しなかった場合は、
watch機能を無効化して動作するようにします。

# 将来の目標

testコマンドが `test.js` を `~/.carton` から配送しようとして失敗しているバグがあります。
この変更を活用して、これを自動テストするつもりです。

# 実装

## b48eb77

watchするときにその対象がターミナルに出力されるが、
その処理をdevコマンドから Server に移す。
実際に watch処理をやっているのは Serverであるため。

こうすると、他の箇所からも Server を利用してwatchする場合にログが出て便利。
なお、現状は他の利用箇所はない。

## 93dcdf5

パイプを受け取るコマンド引数をオプショナルにします。
ただし、watch対象ディレクトリが指定されている場合は省略を禁じます。
