### PR TITLE
ToolchainErrorにレスポンスの内容も含めてログに出す

### DIFF
--- a/Sources/SwiftToolchain/ToolchainError.swift
+++ b/Sources/SwiftToolchain/ToolchainError.swift
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Foundation
 import CartonHelpers
 
 enum ToolchainError: Error, CustomStringConvertible {
   case directoryDoesNotExist(AbsolutePath)
   case invalidInstallationArchive(AbsolutePath)
   case invalidVersion(version: String)
-  case invalidResponse(url: String, status: Int)
+  case notHTTPURLResponse(url: String)
+  case invalidResponse(url: String, status: Int, body: Data)
   case unsupportedOperatingSystem
   case noInstallationDirectory(path: String)
 
@@ -30,8 +32,12 @@ enum ToolchainError: Error, CustomStringConvertible {
       return "Invalid toolchain/SDK archive was installed at path \(path)"
     case let .invalidVersion(version):
       return "Invalid version \(version)"
-    case let .invalidResponse(url: url, status: status):
-      return "Response from \(url) had invalid status \(status) or didn't contain body"
+    case let .notHTTPURLResponse(url: url):
+      return "Response from \(url) is not HTTPURLResponse"
+    case let .invalidResponse(url: url, status: status, body: body):
+      var t = "Response from \(url) had invalid status \(status) with a body of \(body.count) bytes: "
+      t += String(decoding: body, as: UTF8.self)
+      return t
     case .unsupportedOperatingSystem:
       return "This version of the operating system is not supported"
     case let .noInstallationDirectory(path):

--- a/Sources/SwiftToolchain/ToolchainManagement.swift
+++ b/Sources/SwiftToolchain/ToolchainManagement.swift
@@ -165,10 +165,12 @@ public class ToolchainSystem {
     let request = URLRequest(url: URL(string: releaseURL)!)
     let (data, response) = try await URLSession.shared.data(for: request)
     guard let httpResponse = response as? HTTPURLResponse else {
-      throw ToolchainError.invalidResponse(url: releaseURL, status: -1)
+      throw ToolchainError.notHTTPURLResponse(url: releaseURL)
     }
     guard 200..<300 ~= httpResponse.statusCode else {
-      throw ToolchainError.invalidResponse(url: releaseURL, status: httpResponse.statusCode)
+      throw ToolchainError.invalidResponse(
+        url: releaseURL, status: httpResponse.statusCode, body: data
+      )
     }
     terminal.write("Response contained body, parsing it now...\n", inColor: .green)
 


### PR DESCRIPTION
# 課題

GitHub APIにアクセスして失敗した時、そのレスポンスがログに出力されないため、
以下のように CI でそれが起きた時、問題の詳細が分からず修正が困難です。

https://github.com/swiftwasm/carton/actions/runs/9120974490/job/25079364661?pr=434#step:8:413

# 提案

ToolchainError に レスポンスボディを含めるようにして、ログに出します。

# 確認

手元では以下のように出力が得られました。
URL をわざと間違えています。

```
Response from https://api.github.com/repos/swiftwasm/swiftxx/releases/tags/swift-wasm-5.9.2-RELEASE had invalid status 404 with a body of 118 bytes: {"message":"Not Found","documentation_url":"https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name"}
```