### PR TITLE
テストで使われている findSwiftExecutable を一般化して findExecutable を実装する

### DIFF
--- a/Tests/CartonCommandTests/CommandTestHelper.swift
+++ b/Tests/CartonCommandTests/CommandTestHelper.swift
@@ -42,7 +42,7 @@ extension XCTest {
       throw CommandTestError("Output from \(whichBin) is not UTF-8 string")
     }
     let path = string.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard path.isEmpty else {
+    guard !path.isEmpty else {
       throw CommandTestError("Output from \(whichBin) is empty")
     }
     return try AbsolutePath(validating: path)


### PR DESCRIPTION
# 課題

テストでは `findSwiftExecutable` という関数が便利に使われていますが、
`swift` コマンド以外のコマンドを探すことができません。
#434 のように他のコマンドも探せると便利です。

# 提案

`findExecutable` を実装します。

見つからなかった場合には以下のようにエラーメッセージを出します。

```
/Users/omochi/github/swiftwasm/carton/Tests/CartonCommandTests/CommandTestHelper.swift:38: error: -[CartonCommandTests.TestCommandTests testWithNoArguments] : failed: caught error: "Executable foobar was not found: status=1"
```

# 背景

#434 で curl を使おうとしたらどうやら見つからなかったのですが、
`findExecutable` の実装上エラーログが貧弱で対処しづらそうでした。

#434 の変更をなるべく小さくするため、
この改善だけ単品で切り出したパッチを作りました。