### PR TITLE
CartonHelpers.Processの環境変数設定機能のバグを直す

### DIFF
--- a/Sources/CartonHelpers/Basics/Process/ProcessEnv.swift
+++ b/Sources/CartonHelpers/Basics/Process/ProcessEnv.swift
@@ -10,11 +10,13 @@
 
 import Foundation
 
-public struct ProcessEnvironmentKey {
+public struct ProcessEnvironmentKey: CustomStringConvertible {
   public let value: String
   public init(_ value: String) {
     self.value = value
   }
+
+  public var description: String { value }
 }
 
 extension ProcessEnvironmentKey: Encodable {

--- a/Tests/CartonTests/ProcessTests.swift
+++ b/Tests/CartonTests/ProcessTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import CartonHelpers
+
+final class ProcessTests: XCTestCase {
+  func testProcessEnv() async throws {
+    let proc = Process(
+      arguments: ["/usr/bin/env"],
+      environmentBlock: ["PATH": "/usr/local/bin:/usr/bin"]
+    )
+    try proc.launch()
+    let result = try await proc.waitUntilExit()
+    let out = try result.utf8Output()
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    XCTAssertEqual(out, "PATH=/usr/local/bin:/usr/bin")
+  }
+}


### PR DESCRIPTION
# 課題

`CartonHelpers.Process` の環境変数設定機能が壊れています。
これを介して `env` コマンドを実行すると、以下のようなおかしな文字列が得られます。

```
ProcessEnvironmentKey(value: "PATH")=/usr/local/bin:/usr/bin
```

期待される正しい挙動は

```
PATH=/usr/local/bin:/usr/bin
```

です。

# 内容

このパッチはこのバグを修正します。
また、期待した結果が得られるか確認する自動テストを追加します。

# 懸念

このソースコードは swift-tools-support-core から派生しているようです。
そのため、このプロジェクト独自の変更はメンテナンス性を低下させる恐れがあります。
すでに TSC自体が deprecated だからどうでもいいですかね。