### PR TITLE
`.carton` ディレクトリを CI 上で作成するのをやめる

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,14 +34,6 @@ jobs:
           swift -v
           swift build
 
-      - name: Build and install JavaScript and sanitizer resources
-        run: |
-          set -ex
-          npm install
-          swift run carton-release hash-archive
-          mkdir -p $HOME/.carton
-          cp -r static $HOME/.carton
-
       - name: Run Tests
         run: swift test
         env:


### PR DESCRIPTION
# 課題

`.carton` ディレクトリが CI 上では作成されています。

その結果、本来存在しないはずの `.carton` ディレクトリが存在する事と、
本来参照しないはずの `.carton` ディレクトリを参照するバグ
の2つが組み合わさり、
本来生じるはずの不具合が回避されるという問題が起きています。

これによって #434 で取り組んでいるCIによるバグの検出が失敗し、
バグがないかのように動作してしまっています。

# 内容

CI で `.carton` を作成する処理を削除します。