### PR TITLE
`HashArchive.swift` の不要なimportとletを消す

### DIFF
--- a/Sources/carton-release/HashArchive.swift
+++ b/Sources/carton-release/HashArchive.swift
@@ -15,7 +15,6 @@
 import ArgumentParser
 import CartonHelpers
 import Foundation
-import WasmTransformer
 
 struct HashArchive: AsyncParsableCommand {
   /** Converts a hexadecimal hash string to Swift code that represents an archive of static assets.
@@ -36,7 +35,6 @@ struct HashArchive: AsyncParsableCommand {
   }
 
   func run() async throws {
-    let terminal = InteractiveWriter.stdout
     let cwd = localFileSystem.currentWorkingDirectory!
     let staticPath = try AbsolutePath(validating: "static", relativeTo: cwd)
 


### PR DESCRIPTION
使っていない let 変数があり、警告が出ているので、消します。
ビルド全体において、警告が出るのはここだけなので、これで綺麗になります。

不要な `import WasmTransformer` を消します。

`WasmTransformer` を利用している箇所は他には `Bundle.swift` だけでとても少ないので
整理しておくと依存箇所がわかりやすくて良いと思います。