### PR TITLE
ツールチェーン取得における GitHub API の利用時に認証をする

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run Tests
         run: swift test
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: xxxx
 
   swift-test-linux:
     name: Build and test on Linux with Swift ${{ matrix.swift_version }}
@@ -70,4 +70,4 @@ jobs:
       - run: swift build
       - run: swift test
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: xxxx

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run Tests
         run: swift test
         env:
-          GITHUB_TOKEN: xxxx
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   swift-test-linux:
     name: Build and test on Linux with Swift ${{ matrix.swift_version }}
@@ -70,4 +70,4 @@ jobs:
       - run: swift build
       - run: swift test
         env:
-          GITHUB_TOKEN: xxxx
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# 課題

ツールチェーンをインストールするときに GitHub API を利用していますが、
これが CI などではレートリミットに到達して CI が通らなくなってしまうことがあります。

以下は実際にそうなった例です。

https://github.com/swiftwasm/carton/actions/runs/9129608385/job/25104562386?pr=434#step:8:547

なお、このログは #435 によって表示されるようになりました。

# 内容

GitHub API に対してトークン認証を行うようにします。
トークンは `ToolchainSystem` の引数で与えられる他、
環境変数の `GITHUB_TOKEN` を参照して利用します。

# 動作確認

トークン認証が成功していても、そもそも認証していなくても、
ある程度は API が使えるため検証が難しいです。

代わりに、00030d3 でわざと不正なトークンを設定し、認証エラーを引き起こすことで、
通信に正しくトークンが載っていることを確認しました。

mac

```
Swift/ErrorType.swift:200: Fatal error: Error raised at top level: Response from https://api.github.com/repos/swiftwasm/swift/releases/tags/swift-wasm-5.9.2-RELEASE had invalid status 401 with a body of 80 bytes: {"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}
```

https://github.com/swiftwasm/carton/actions/runs/9131174999/job/25109787976?pr=440#step:8:133

Linux

```
Swift/ErrorType.swift:200: Fatal error: Error raised at top level: Response from https://api.github.com/repos/swiftwasm/swift/releases/tags/swift-wasm-5.9.2-RELEASE had invalid status 401 with a body of 90 bytes: {
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest"
}
```

https://github.com/swiftwasm/carton/actions/runs/9131174999/job/25109787717?pr=440#step:8:753

GitHubが送ってくるJSONのフォーマットがOSによってちょっと違うの気になりますが、
ここでは関係ないのでスルーします。