### PR TITLE
CartonPluginSharedのREADMEを修正する

### DIFF
--- a/Plugins/CartonPluginShared/README.md
+++ b/Plugins/CartonPluginShared/README.md
@@ -1,1 +1,3 @@
-This directory contains symbolic links to shared source code among the Carton plugins. This is a temporary workaround until SwiftPM supports it natively.
+This directory contains shared source code for the Carton plugins.
+Plugins reference this directory using symbolic links to use these sources.
+This is a temporary workaround until SwiftPM supports it natively.


### PR DESCRIPTION
原文だと、
「このディレクトリにはプラグインが共有するソースへのシンボリックリンクが含まれる」
と書いてあります。

しかし実際にはこのディレクトリにはシンボリックリンクは含まれていません。
代わりにソースコードが直接置かれています。
そして、プラグイン達がこのディレクトリ自体をシンボリックリンクで参照しています。

そこで、実態にあった説明文に更新します。
