### PR TITLE
フリーズしてしまうブラウザテストを無効化する

### DIFF
--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -68,9 +68,9 @@ final class DevCommandTests: XCTestCase {
       <!DOCTYPE html>
       <html>
         <head>
-            <meta charset="utf-8" />
-            <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <script type="module" src="dev.js"></script>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <script type="module" src="dev.js"></script>
         </head>
         <body>
         </body>

--- a/Tests/CartonCommandTests/TestCommandTests.swift
+++ b/Tests/CartonCommandTests/TestCommandTests.swift
@@ -27,6 +27,10 @@ private enum Constants {
   static let failTestPackageName = "FailTest"
 }
 
+func skipBrowserTest() throws {
+  throw XCTSkip("[FIXME] Running tests in the browser is currently disabled because it causes freezing")
+}
+
 final class TestCommandTests: XCTestCase {
   func testWithNoArguments() throws {
     try withFixture(Constants.testAppPackageName) { packageDirectory in
@@ -75,6 +79,7 @@ final class TestCommandTests: XCTestCase {
   }
 
   func testHeadlessBrowser() throws {
+    try skipBrowserTest()
     guard Process.findExecutable("safaridriver") != nil else {
       throw XCTSkip("WebDriver is required")
     }
@@ -88,10 +93,12 @@ final class TestCommandTests: XCTestCase {
   }
 
   func testHeadlessBrowserWithCrash() throws {
+    try skipBrowserTest()
     try checkCartonTestFail(fixture: Constants.crashTestPackageName)
   }
 
   func testHeadlessBrowserWithFail() throws {
+    try skipBrowserTest()
     try checkCartonTestFail(fixture: Constants.failTestPackageName)
   }
 
@@ -111,6 +118,7 @@ final class TestCommandTests: XCTestCase {
   // This test is prone to hanging on Linux.
   #if os(macOS)
     func testEnvironmentDefaultBrowser() throws {
+      try skipBrowserTest()
       try withFixture(Constants.testAppPackageName) { packageDirectory in
         let expectedTestSuiteCount = 1
         let expectedTestsCount = 1


### PR DESCRIPTION
現在 dev server が `test.js` を配送できないバグがあり、
ブラウザでのテストの実行が進行しません。

`carton test` コマンドの自動テストはこの影響でフリーズしてしまうため、
そのようなブラウザのテストを無効化します。

この問題は元々 #420 から発生していましたが、
`.carton` ディレクトリが残っていると発現しないため隠れていました。

#438 によりCI環境からも `.carton` ディレクトリが廃止されたため、
その影響で CI の自動テストが停止しなくなっていました。

無効化においては メッセージを含めた `XCTSkip` を利用することで、
CIログで状況がわかるようにしておくことで、
将来この配送の問題を修正するタスクに取り組むことを見落としにくくします。

# その他の変更

#442 の変更によってテストが失敗していました。
テストケースの追従を忘れていたため、修正します。

# 将来の目標

jsが配送されないバグは #434 で現状を自動テストできるようにしてから修正する計画です。