### PR TITLE
[DNM] [WIP] CIのSwiftバージョンを5.9.2に引き上げる。armマシンのmac OS Sonomaのテスト環境を追加する。

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -35,7 +35,7 @@ jobs:
         run: swift build --build-tests
       
       - name: Run tests
-        run: swift test -v
+        run: swift test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Check Swift version
         run: swift --version
 
-      - name: Check Swift version
-        run: swift --version
-
       - name: Install dependencies for macOS
         run: brew bundle
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,22 +8,25 @@ on:
 
 jobs:
   swift-test-macos:
-    name: Build and test on macOS with Swift ${{ matrix.swift_version }}
+    name: Build and test on ${{ matrix.os }} with Swift ${{ matrix.swift-version }}, Xcode  ${{ matrix.xcode }}
     timeout-minutes: 40
-    runs-on: macos-13
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - os: macos-13 # TODO: macos-14 runner expected in October-December 2023
-            swift_version: "5.9"
-            xcode: /Applications/Xcode_15.0.app/Contents/Developer
+          - os: macos-14
+            xcode: "15.4"
+            swift-version: "5.10"
+          - os: macos-13
+            xcode: "15.2"
+            swift-version: "5.9.2"
 
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
       - name: Select Xcode version
-        run: sudo xcode-select --switch ${{ matrix.xcode }}
+        run: sudo xcode-select --switch /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
       - name: Check Swift version
         run: swift --version
@@ -47,8 +50,8 @@ jobs:
       matrix:
         include:
           - swift:
-              dir: "swift-5.9-release/ubuntu2204"
-              version: "swift-5.9-RELEASE"
+              dir: "swift-5.9.2-release/ubuntu2204"
+              version: "swift-5.9.2-RELEASE"
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-14
+          - os: macos-14-arm64
             xcode: "15.4"
             swift-version: "5.10"
           - os: macos-13

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,24 +19,22 @@ jobs:
             xcode: /Applications/Xcode_15.0.app/Contents/Developer
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repository
+        uses: actions/checkout@v4
 
       - name: Select Xcode version
         run: sudo xcode-select --switch ${{ matrix.xcode }}
 
+      - name: Check Swift version
+        run: swift --version
+
       - name: Install dependencies for macOS
         run: brew bundle
 
-      - uses: bytecodealliance/actions/wasmtime/setup@v1
-
       - name: Build the project
-        run: |
-          swift -v
-          swift build
+        run: swift build --build-tests
       
-      - run: swift build -v --build-tests
-
-      - name: Run Tests
+      - name: Run tests
         run: swift test -v
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,24 +51,30 @@ jobs:
               version: "swift-5.9-RELEASE"
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repository
+        run: actions/checkout@v4
 
-      - uses: ./.github/actions/install-swift
+      - name: Install Swift toolchain
+        uses: ./.github/actions/install-swift
         with:
           swift-dir: ${{ matrix.swift.dir }}
           swift-version: ${{ matrix.swift.version }}
 
-      - name: Install dependent packages for Wasm
+      - name: Check Swift version
+        run: swift --version
+
+      - name: Install dependent packages for WebAssembly
         run: >
           sudo apt-get update && sudo apt-get install -y
           wabt binaryen
 
-      - uses: bytecodealliance/actions/wasmtime/setup@v1
+      - name: Install WebAssembly runtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '20'
-      - run: swift build
-      - run: swift test
+      - name: Build the project
+        run: swift build --build-tests
+
+      - name: Run tests
+        run: swift test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        run: actions/checkout@v4
+        uses: actions/checkout@v4
 
       - name: Install Swift toolchain
         uses: ./.github/actions/install-swift

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   swift-test-macos:
-    name: Build and test on ${{ matrix.os }} with Swift ${{ matrix.swift-version }}, Xcode  ${{ matrix.xcode }}
+    name: Build and test on ${{ matrix.os }} with Swift ${{ matrix.swift }}, Xcode  ${{ matrix.xcode }}
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
     strategy:
@@ -16,10 +16,10 @@ jobs:
         include:
           - os: macos-14-arm64
             xcode: "15.4"
-            swift-version: "5.10"
+            swift: "5.10"
           - os: macos-13
             xcode: "15.2"
-            swift-version: "5.9.2"
+            swift: "5.9.2"
 
     steps:
       - name: Checkout the repository

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,3 @@
 brew "binaryen"
 brew "wabt"
+brew "wasmtime"


### PR DESCRIPTION
# 5.9.2 に引き上げる

現在CartonはSwift 5.9.2 をサポート下限としています。
しかし、CIは5.9 (.0) を使っているため、下記の警告が出ています。

```
Swift 5.9.1 or earlier is not supported by carton
```

サポートしていない環境をテストする意味はないので、
テスト環境を5.9.2 に引き上げます。

# macOS Sonoma を追加する

最新のmacOS 環境は Sonoma, Xcode 15.4, Swift 5.10です。
また、armマシンのmacの普及も進んでいます。
これを自動テストの環境に追加します。

# LinuxのSwift5.10について

Linuxでも5.10を追加したいですが、
現在 Wasm ビルドで Linux の `swift test` が使えないという問題があります。
そのため、単純に追加してもCIが壊れてしまいます。

Cartonのテストに関しては、この症状と関係ない部分もあるし、
ビルドだけでもテストする意味はあるので、
これは追って、問題を回避する仕組みと合わせて導入するつもりです。