### PR TITLE
CIのLinux環境にSwift 5.10を追加する

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -47,6 +47,9 @@ jobs:
       matrix:
         include:
           - swift:
+              dir: "swift-5.10-release/ubuntu2204"
+              version: "swift-5.10-RELEASE"
+          - swift:
               dir: "swift-5.9.2-release/ubuntu2204"
               version: "swift-5.9.2-RELEASE"
 


### PR DESCRIPTION
現在の標準のSwiftバージョンである5.10をCIに追加します。

これによって、CLIツールとしてのcartonが 5.10 で **ビルド** できるかどうかがテストされます。

ただし、ビルド後の **実行** については、実際のところテストされません。
`carton` コマンドはホスト環境で実行されますが、
その先のプラグインとフロントエンドコマンドについては、
cartonが管理・インストールする swift 5.9.2 ツールチェーンが使われるからです。

なお現状、wasmビルドについては `$ swift test` が動かないという既知の問題がありますが、
上述の通りでテストの実行は 5.9.2 が使われるので、
特に問題は生じないはずです。

# 将来の目標

## mac について

mac環境は別の作業とします。

## 5.10 での実行について

上述の通り、 wasmで `$ swift test` は動きません。
ただし、wasm executableは動くので、
`carton-frontend dev` は、 `5.10` でビルドした wasm executable を乗っけて、
同じく `5.10` でビルドした `carton-frontend dev` を直接使って、
起動することが可能です。

このように、 carton によるツールチェーンを迂回して、
直接 frontend を動かす利用方法の自動テストを今後実装するつもりです。