### PR TITLE
Stop defining test utilities under XCTest

### DIFF
--- a/Tests/CartonCommandTests/CommandTestHelper.swift
+++ b/Tests/CartonCommandTests/CommandTestHelper.swift
@@ -24,89 +24,87 @@ struct CommandTestError: Swift.Error & CustomStringConvertible {
   var description: String
 }
 
-extension XCTest {
-  func findExecutable(name: String) throws -> AbsolutePath {
-    let whichBin = "/usr/bin/which"
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: whichBin)
-    process.arguments = [name]
-    let output = Pipe()
-    process.standardOutput = output
-    try process.run()
-    process.waitUntilExit()
-    guard process.terminationStatus == EXIT_SUCCESS else {
-      throw CommandTestError("Executable \(name) was not found: status=\(process.terminationStatus)")
-    }
-    let outputData = output.fileHandleForReading.readDataToEndOfFile()
-    guard let string = String(data: outputData, encoding: .utf8) else {
-      throw CommandTestError("Output from \(whichBin) is not UTF-8 string")
-    }
-    let path = string.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !path.isEmpty else {
-      throw CommandTestError("Output from \(whichBin) is empty")
-    }
-    return try AbsolutePath(validating: path)
+func findExecutable(name: String) throws -> AbsolutePath {
+  let whichBin = "/usr/bin/which"
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: whichBin)
+  process.arguments = [name]
+  let output = Pipe()
+  process.standardOutput = output
+  try process.run()
+  process.waitUntilExit()
+  guard process.terminationStatus == EXIT_SUCCESS else {
+    throw CommandTestError("Executable \(name) was not found: status=\(process.terminationStatus)")
   }
-
-  func findSwiftExecutable() throws -> AbsolutePath {
-    try findExecutable(name: "swift")
+  let outputData = output.fileHandleForReading.readDataToEndOfFile()
+  guard let string = String(data: outputData, encoding: .utf8) else {
+    throw CommandTestError("Output from \(whichBin) is not UTF-8 string")
   }
+  let path = string.trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !path.isEmpty else {
+    throw CommandTestError("Output from \(whichBin) is empty")
+  }
+  return try AbsolutePath(validating: path)
+}
 
-  struct SwiftRunResult {
-    var exitCode: Int32
-    var stdout: String
-    var stderr: String
+func findSwiftExecutable() throws -> AbsolutePath {
+  try findExecutable(name: "swift")
+}
 
-    func assertZeroExit(_ file: StaticString = #file, line: UInt = #line) {
-      XCTAssertEqual(exitCode, 0, "stdout: " + stdout + "\nstderr: " + stderr, file: file, line: line)
+struct SwiftRunResult {
+  var exitCode: Int32
+  var stdout: String
+  var stderr: String
+
+  func assertZeroExit(_ file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(exitCode, 0, "stdout: " + stdout + "\nstderr: " + stderr, file: file, line: line)
+  }
+}
+
+func swiftRunProcess(
+  _ arguments: [CustomStringConvertible],
+  packageDirectory: URL
+) throws -> (Foundation.Process, stdout: Pipe, stderr: Pipe) {
+  let process = Process()
+  process.executableURL = try findSwiftExecutable().asURL
+  process.arguments = ["run"] + arguments.map(\.description)
+  process.currentDirectoryURL = packageDirectory
+  let stdoutPipe = Pipe()
+  process.standardOutput = stdoutPipe
+  let stderrPipe = Pipe()
+  process.standardError = stderrPipe
+
+  func setSignalForwarding(_ signalNo: Int32) {
+    signal(signalNo, SIG_IGN)
+    let signalSource = DispatchSource.makeSignalSource(signal: signalNo)
+    signalSource.setEventHandler {
+      signalSource.cancel()
+      process.interrupt()
     }
+    signalSource.resume()
   }
+  setSignalForwarding(SIGINT)
+  setSignalForwarding(SIGTERM)
 
-  func swiftRunProcess(
-    _ arguments: [CustomStringConvertible],
-    packageDirectory: URL
-  ) throws -> (Foundation.Process, stdout: Pipe, stderr: Pipe) {
-    let process = Process()
-    process.executableURL = try findSwiftExecutable().asURL
-    process.arguments = ["run"] + arguments.map(\.description)
-    process.currentDirectoryURL = packageDirectory
-    let stdoutPipe = Pipe()
-    process.standardOutput = stdoutPipe
-    let stderrPipe = Pipe()
-    process.standardError = stderrPipe
+  try process.run()
 
-    func setSignalForwarding(_ signalNo: Int32) {
-      signal(signalNo, SIG_IGN)
-      let signalSource = DispatchSource.makeSignalSource(signal: signalNo)
-      signalSource.setEventHandler {
-        signalSource.cancel()
-        process.interrupt()
-      }
-      signalSource.resume()
-    }
-    setSignalForwarding(SIGINT)
-    setSignalForwarding(SIGTERM)
+  return (process, stdoutPipe, stderrPipe)
+}
 
-    try process.run()
+@discardableResult
+func swiftRun(_ arguments: [CustomStringConvertible], packageDirectory: URL) throws
+  -> SwiftRunResult
+{
+  let (process, stdoutPipe, stderrPipe) = try swiftRunProcess(
+    arguments, packageDirectory: packageDirectory)
+  process.waitUntilExit()
 
-    return (process, stdoutPipe, stderrPipe)
-  }
+  let stdout = String(
+    data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)!
+    .trimmingCharacters(in: .whitespacesAndNewlines)
 
-  @discardableResult
-  func swiftRun(_ arguments: [CustomStringConvertible], packageDirectory: URL) throws
-    -> SwiftRunResult
-  {
-    let (process, stdoutPipe, stderrPipe) = try swiftRunProcess(
-      arguments, packageDirectory: packageDirectory)
-    process.waitUntilExit()
-
-    let stdout = String(
-      data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)!
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-
-    let stderr = String(
-      data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)!
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    return SwiftRunResult(exitCode: process.terminationStatus, stdout: stdout, stderr: stderr)
-  }
+  let stderr = String(
+    data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)!
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  return SwiftRunResult(exitCode: process.terminationStatus, stdout: stdout, stderr: stderr)
 }


### PR DESCRIPTION
`CommandTestHelper.swift` に書かれたテスト用のユーティリティメソッドが、
`XCTest` のエクステンションとして定義されています。

内容が特に `XCTest` のインスタンスと紐付ける必要がないもので、
設計として不適切なため脱エクステンションします。

将来的にこの辺りのプロセス制御系のコードを、
プロジェクト全体で整理したいので、
その際の変更を小さくする意図もあります。

なお、経緯を調べたところ、最初にこのエクステションを定義した時には、
`self` を参照してそこから `Bundle` を取得するロジックが書かれていたので、
メソッドとして定義するのは合理的です。
https://github.com/swiftwasm/carton/blob/5fe8c8edac087f1ed3de487c327a6621e622d1b1/Tests/CartonCLITests/CommandTestHelper.swift#L181
今はそのメンバはありません。

