### PR TITLE
Bug fix on makeTemporaryFile

### DIFF
--- a/Sources/carton/main.swift
+++ b/Sources/carton/main.swift
@@ -156,7 +156,7 @@ func makeTemporaryFile(prefix: String, in directory: URL? = nil) throws -> URL {
     copy[template.count] = 0
     guard mkstemp(copy.baseAddress!) != -1 else {
       let error = errnoString
-      throw CartonCommandError("Failed to create a temporary file at \(template): \(error)")
+      throw CartonCommandError("Failed to make a temporary file at \(template): \(error)")
     }
     return String(cString: copy.baseAddress!)
   }

--- a/Sources/carton/main.swift
+++ b/Sources/carton/main.swift
@@ -34,6 +34,13 @@ import CartonHelpers
 import Foundation
 import SwiftToolchain
 
+struct CartonCommandError: Error & CustomStringConvertible {
+  init(_ description: String) {
+    self.description = description
+  }
+  var description: String
+}
+
 extension Foundation.Process {
   internal static func checkRun(
     _ executableURL: URL, arguments: [String], forwardExit: Bool = false
@@ -99,8 +106,7 @@ func derivePackageCommandArguments(
     packageArguments += ["--disable-sandbox"]
   case "test":
     // 1. Ask the plugin process to generate the build command based on the given options
-    let commandFile = makeTemporaryFile(
-      prefix: "test-build", suffix: "args", in: URL(fileURLWithPath: NSTemporaryDirectory()))
+    let commandFile = try makeTemporaryFile(prefix: "test-build")
     try Foundation.Process.checkRun(
       swiftExec,
       arguments: packageArguments + pluginArguments + [
@@ -132,15 +138,25 @@ func derivePackageCommandArguments(
   return packageArguments + pluginArguments + ["carton-\(subcommand)"] + cartonPluginArguments
 }
 
-func makeTemporaryFile(prefix: String, suffix: String, in directory: URL) -> URL {
-  var template = directory.appendingPathComponent("carton-XXXXXX").path
-  let result = template.withUTF8 { template in
+var errnoString: String {
+  String(cString: strerror(errno))
+}
+
+var temporaryDirectory: URL {
+  URL(fileURLWithPath: NSTemporaryDirectory())
+}
+
+func makeTemporaryFile(prefix: String, in directory: URL? = nil) throws -> URL {
+  let directory = directory ?? temporaryDirectory
+  var template = directory.appendingPathComponent("\(prefix)XXXXXX").path
+  let result = try template.withUTF8 { template in
     let copy = UnsafeMutableBufferPointer<CChar>.allocate(capacity: template.count + 1)
     defer { copy.deallocate() }
     template.copyBytes(to: copy)
     copy[template.count] = 0
     guard mkstemp(copy.baseAddress!) != -1 else {
-      fatalError("Failed to create a temporary directory")
+      let error = errnoString
+      throw CartonCommandError("Failed to create a temporary file at \(template): \(error)")
     }
     return String(cString: copy.baseAddress!)
   }


### PR DESCRIPTION
# バグ

`carton.makeTemporaryFile` にバグがありました。

## prefixを使っていない

引数に渡された prefix が使われていません。

## suffixを使っていない(使えない)

引数に渡された suffix が使われていません。
そもそも下請けの `mkstemp` はsuffixが使えません。

## エラーメッセージが変

ファイルを作る関数なのに文言がディレクトリになっています。

# 改善

修正のついでに以下の改善をします。

## デフォルトのディレクトリ

ディレクトリを省略可能にし、デフォルトで `NSTemporaryDirectory` を使うようにします。
用途から考えると妥当で便利だと思います。

## 下層のエラーを読む

`errno` を参照してエラー文言に添えます。

## クラッシュさせずに例外を投げる

失敗してもクラッシュではなく例外を投げます。

# 将来の目的

carton, プラグイン, フロントエンドで様々なユーティリティが多重に実装されています。
これを統合したいと思っていて、
その前準備としてこの関数の仕様を整えました。

