### PR TITLE
[DNM] コマンドの自動テストでストリームしながらキャプチャするためにteeコマンドを使う

### DIFF
--- a/Sources/CartonHelpers/CartonHelpersError.swift
+++ b/Sources/CartonHelpers/CartonHelpersError.swift
@@ -1,0 +1,6 @@
+struct CartonHelpersError: Error & CustomStringConvertible {
+  init(_ description: String) {
+    self.description = description
+  }
+  var description: String
+}

--- a/Sources/CartonHelpers/FileUtils.swift
+++ b/Sources/CartonHelpers/FileUtils.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public enum FileUtils {
+  static var errnoString: String {
+    String(cString: strerror(errno))
+  }
+
+  public static var temporaryDirectory: URL {
+    URL(fileURLWithPath: NSTemporaryDirectory())
+  }
+
+  public static func makeTemporaryFile(prefix: String, in directory: URL? = nil) throws -> URL {
+    let directory = directory ?? temporaryDirectory
+    var template = directory.appendingPathComponent("\(prefix)XXXXXX").path
+    let result = try template.withUTF8 { template in
+      let copy = UnsafeMutableBufferPointer<CChar>.allocate(capacity: template.count + 1)
+      defer { copy.deallocate() }
+      template.copyBytes(to: copy)
+      copy[template.count] = 0
+      guard mkstemp(copy.baseAddress!) != -1 else {
+        let error = errnoString
+        throw CartonHelpersError("Failed to make a temporary file at \(template): \(error)")
+      }
+      return String(cString: copy.baseAddress!)
+    }
+    return URL(fileURLWithPath: result)
+  }
+}

--- a/Sources/carton/main.swift
+++ b/Sources/carton/main.swift
@@ -34,13 +34,6 @@ import CartonHelpers
 import Foundation
 import SwiftToolchain
 
-struct CartonCommandError: Error & CustomStringConvertible {
-  init(_ description: String) {
-    self.description = description
-  }
-  var description: String
-}
-
 extension Foundation.Process {
   internal static func checkRun(
     _ executableURL: URL, arguments: [String], forwardExit: Bool = false

--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -31,7 +31,7 @@ final class DevCommandTests: XCTestCase {
     func testWithNoArguments() async throws {
       // FIXME: Don't assume a specific port is available since it can be used by others or tests
       try await withFixture("EchoExecutable") { packageDirectory in
-        let (process, _, _) = try swiftRunProcess(
+        let process = try swiftRunProcess(
           ["carton", "dev", "--verbose", "--skip-auto-open"],
           packageDirectory: packageDirectory.url
         )
@@ -43,7 +43,7 @@ final class DevCommandTests: XCTestCase {
     func testWithArguments() async throws {
       // FIXME: Don't assume a specific port is available since it can be used by others or tests
       try await withFixture("EchoExecutable") { packageDirectory in
-        let (process, _, _) = try swiftRunProcess(
+        let process = try swiftRunProcess(
           ["carton", "dev", "--verbose", "--port", "8081", "--skip-auto-open"],
           packageDirectory: packageDirectory.url
         )
@@ -53,7 +53,7 @@ final class DevCommandTests: XCTestCase {
     }
   #endif
 
-  func checkForExpectedContent(process: Process, at url: String) async {
+  func checkForExpectedContent(process: SwiftRunProcess, at url: String) async {
     // client time out for connecting and responding
     let timeOut: Int64 = 60
 
@@ -86,7 +86,7 @@ final class DevCommandTests: XCTestCase {
     // give the server some time to start
     repeat {
       // Don't wait for anything if the process is dead.
-      guard process.isRunning else {
+      guard process.process.isRunning else {
         break
       }
 
@@ -109,7 +109,7 @@ final class DevCommandTests: XCTestCase {
     } while count < polls && response == nil
 
     // end the process regardless of success
-    process.terminate()
+    process.process.terminate()
 
     if let response = response {
       XCTAssertTrue(response.statusCode == 200, "Response was not ok")

--- a/Tests/CartonCommandTests/TestCommandTests.swift
+++ b/Tests/CartonCommandTests/TestCommandTests.swift
@@ -32,41 +32,41 @@ func skipBrowserTest() throws {
 }
 
 final class TestCommandTests: XCTestCase {
-  func testWithNoArguments() throws {
-    try withFixture(Constants.testAppPackageName) { packageDirectory in
-      let result = try swiftRun(
+  func testWithNoArguments() async throws {
+    try await withFixture(Constants.testAppPackageName) { packageDirectory in
+      let result = try await swiftRun(
         ["carton", "test"], packageDirectory: packageDirectory.url
       )
-      result.assertZeroExit()
+      try result.checkSuccess()
     }
   }
 
-  func testEnvironmentNodeNoJSKit() throws {
-    try withFixture(Constants.testAppPackageName) { packageDirectory in
-      let result = try swiftRun(
+  func testEnvironmentNodeNoJSKit() async throws {
+    try await withFixture(Constants.testAppPackageName) { packageDirectory in
+      let result = try await swiftRun(
         ["carton", "test", "--environment", "node"], packageDirectory: packageDirectory.url
       )
-      result.assertZeroExit()
+      try result.checkSuccess()
     }
   }
 
-  func testEnvironmentNodeJSKit() throws {
-    try withFixture(Constants.nodeJSKitPackageName) { packageDirectory in
-      let result = try swiftRun(
+  func testEnvironmentNodeJSKit() async throws {
+    try await withFixture(Constants.nodeJSKitPackageName) { packageDirectory in
+      let result = try await swiftRun(
         ["carton", "test", "--environment", "node"], packageDirectory: packageDirectory.url
       )
-      result.assertZeroExit()
+      try result.checkSuccess()
     }
   }
 
-  func testSkipBuild() throws {
-    try withFixture(Constants.nodeJSKitPackageName) { packageDirectory in
-      var result = try swiftRun(
+  func testSkipBuild() async throws {
+    try await withFixture(Constants.nodeJSKitPackageName) { packageDirectory in
+      var result = try await swiftRun(
         ["carton", "test", "--environment", "node"], packageDirectory: packageDirectory.url
       )
-      result.assertZeroExit()
+      try result.checkSuccess()
 
-      result = try swiftRun(
+      result = try await swiftRun(
         [
           "carton", "test", "--environment", "node",
           "--prebuilt-test-bundle-path",
@@ -74,52 +74,52 @@ final class TestCommandTests: XCTestCase {
         ],
         packageDirectory: packageDirectory.url
       )
-      result.assertZeroExit()
+      try result.checkSuccess()
     }
   }
 
-  func testHeadlessBrowser() throws {
+  func testHeadlessBrowser() async throws {
     try skipBrowserTest()
     guard Process.findExecutable("safaridriver") != nil else {
       throw XCTSkip("WebDriver is required")
     }
-    try withFixture(Constants.testAppPackageName) { packageDirectory in
-      let result = try swiftRun(
+    try await withFixture(Constants.testAppPackageName) { packageDirectory in
+      let result = try await swiftRun(
         ["carton", "test", "--environment", "browser", "--headless"],
         packageDirectory: packageDirectory.url
       )
-      result.assertZeroExit()
+      try result.checkSuccess()
     }
   }
 
-  func testHeadlessBrowserWithCrash() throws {
+  func testHeadlessBrowserWithCrash() async throws {
     try skipBrowserTest()
-    try checkCartonTestFail(fixture: Constants.crashTestPackageName)
+    try await checkCartonTestFail(fixture: Constants.crashTestPackageName)
   }
 
-  func testHeadlessBrowserWithFail() throws {
+  func testHeadlessBrowserWithFail() async throws {
     try skipBrowserTest()
-    try checkCartonTestFail(fixture: Constants.failTestPackageName)
+    try await checkCartonTestFail(fixture: Constants.failTestPackageName)
   }
 
-  func checkCartonTestFail(fixture: String) throws {
+  func checkCartonTestFail(fixture: String) async throws {
     guard Process.findExecutable("safaridriver") != nil else {
       throw XCTSkip("WebDriver is required")
     }
-    try withFixture(fixture) { packageDirectory in
-      let result = try swiftRun(
+    try await withFixture(fixture) { packageDirectory in
+      let result = try await swiftRun(
         ["carton", "test", "--environment", "browser", "--headless"],
         packageDirectory: packageDirectory.url
       )
-      XCTAssertNotEqual(result.exitCode, 0)
+      try result.checkSuccess()
     }
   }
 
   // This test is prone to hanging on Linux.
   #if os(macOS)
-    func testEnvironmentDefaultBrowser() throws {
+    func testEnvironmentDefaultBrowser() async throws {
       try skipBrowserTest()
-      try withFixture(Constants.testAppPackageName) { packageDirectory in
+      try await withFixture(Constants.testAppPackageName) { packageDirectory in
         let expectedTestSuiteCount = 1
         let expectedTestsCount = 1
 
@@ -132,11 +132,11 @@ final class TestCommandTests: XCTestCase {
           """
 
         // FIXME: Don't assume a specific port is available since it can be used by others or tests
-        let result = try swiftRun(
+        let result = try await swiftRun(
           ["carton", "test", "--environment", "browser", "--port", "8082"],
           packageDirectory: packageDirectory.url
         )
-        XCTAssertTrue(result.stdout.contains(expectedContent))
+        XCTAssertTrue(try XCTUnwrap(result.utf8Output()).contains(expectedContent))
       }
     }
   #endif


### PR DESCRIPTION
# このPRのステータス

~~#457 に依存しているので、それがマージされるまでは Draft にしておきます。~~

~~レビューの用意ができました。CIを確認中です。~~

実装を修正中です

# 課題

テストの `swiftRun` は、プロセスの終了を待ってから、
パイプの中身を取り出しています。
これには課題があります。

## パイプが詰まるかもしれない

テストでは `swift run carton dev` などのコマンドを実行していますが、
これはマシンの状況によっては、
Swift ツールチェーンのダウンロードから、
テスト対象プロジェクトのビルドなどの多くの処理をします。
その間パイプが全くドレインされないので、
OSにバッファされ続けます。

これが最大容量に達すると、
書き込み側プロセスがフリーズするとか、
シグナルによってプロセスがキルされる恐れがあります。

ちなみにLinuxでは容量は 64KB ぐらいらしいので、
`which` とか `env` のような小さなコマンドでは問題ない実装ですが、
たくさん出力が生じるようなインタラクティブなコマンドでは不適切です。

## 処理が終わるまで結果が見えない

ツールチェーンのダウンロードなどが生じる場合、
一つのプロセス実行に3分ほどかかる場合があります。
この間全く出力がコンソールに現れないため、
状況がわからないし、
なんらかの理由でプロセスがフリーズしている場合、
ゆっくり進んでいる場合と区別がつかず開発しづらいです。

# 背景

テストコードでは、ほとんどの場合がステータスコードをチェックしているだけですが、
一件だけプロセスの出力内容に対するテストが書かれています。

このようなプロセス出力に対するテストは有効で、
むしろもっと増やしていくべきでしょう。

# 提案

課題の解決にはプロセス出力を溜め込まずにストリームするのが簡単ですが、
上述の通りテストでは結果をキャプチャしたいニーズもあります。

そこで `tee` コマンドを使用して、
コンソールにストリームしつつ、ファイルにも溜め込みます。
プロセスが終了したらファイルから読み込んで、
内容の検証のニーズに備えます。

# 実装

メインのプロセスとteeプロセスを繋げて使う場合は、
まずそれぞれのプロセスの停止を待ってから、
その後で出力バッファファイルを読み込みます。

プロセスの停止を待つ処理ですが、`Foundation.waitUntilExit` はブロッキング処理なのが問題です。
swift concurrencyと干渉する恐れがあるので、
asyncのインターフェースを提供すべきでしょう。

その後、プロセスの結果を受け取り、ステータスのチェックをします。
実装の簡単さとデバッグしやすさのため、
そのチェックメソッドは失敗すれば例外を投げ、
例外は出力内容をダンプできると良いでしょう。

teeプロセスの書き込み先については、
テンポラリファイルを適切に準備する必要があります。
これは `carton` モジュールに実装があるので、
これを `CartonHelpers` モジュールに移動してきて、
テストから共用します。

以上の要求に応えるため、
`FoundationProcessResult` 型を実装します。
また、これを握って飛んでいく `FoundationProcessResult.Error` 型を実装します。

これはほぼ `CartonHelpers.ProcessResult` と同じものですが、
`CartonHelpers.Process` ではなく、
`Foundation.Process` と合わせて使うように設計されています。

ちなみにですが、`CartonHelpers.ProcessError` という型が `Process+run.swift` で実装されていますが、
実は `CartonHelpers.ProcessResult.Error` という型があって、ほぼ重複しています。

# 将来の目標

現在 carton において、 `Foudation.Process` と `CartonHelpers.Process` という、
2つのほぼ同じ役割の型が存在し、利用するコードが混在するのでコードが紛らわしいです。

今回実装した `FoundationProcessResult` とその関連メソッドがあれば、
`CartonHelpers.Process` でなければできない事はほぼなくなります。
将来的には `CartonHelpers.Process` の利用を廃止したいと考えています。


