### PR TITLE
Stream command outputs while capturing them for testing

### DIFF
--- a/Sources/CartonHelpers/ProcessEx.swift
+++ b/Sources/CartonHelpers/ProcessEx.swift
@@ -1,0 +1,19 @@
+extension ProcessResult {
+  public mutating func setOutput(_ value: Result<[UInt8], any Swift.Error>) {
+    self = ProcessResult(
+      arguments: arguments,
+      environmentBlock: environmentBlock,
+      exitStatus: exitStatus,
+      output: value,
+      stderrOutput: stderrOutput
+    )
+  }
+
+  @discardableResult
+  public func checkNonZeroExit() throws -> String {
+    guard exitStatus == .terminated(code: 0) else {
+        throw ProcessResult.Error.nonZeroExit(self)
+    }
+    return try utf8Output()
+  }
+}

--- a/Tests/CartonCommandTests/BundleCommandTests.swift
+++ b/Tests/CartonCommandTests/BundleCommandTests.swift
@@ -21,11 +21,12 @@ import XCTest
 @testable import CartonFrontend
 
 final class BundleCommandTests: XCTestCase {
-  func testWithNoArguments() throws {
-    try withFixture("EchoExecutable") { packageDirectory in
+  func testWithNoArguments() async throws {
+    try await withFixture("EchoExecutable") { packageDirectory in
       let bundleDirectory = packageDirectory.appending(component: "Bundle")
 
-      try swiftRun(["carton", "bundle"], packageDirectory: packageDirectory.url)
+      let result = try await swiftRun(["carton", "bundle"], packageDirectory: packageDirectory.url)
+      try result.checkNonZeroExit()
 
       // Confirm that the files are actually in the folder
       XCTAssertTrue(bundleDirectory.exists, "The Bundle directory should exist")
@@ -41,31 +42,31 @@ final class BundleCommandTests: XCTestCase {
     }
   }
 
-  func testWithDebugInfo() throws {
-    try withFixture("EchoExecutable") { packageDirectory in
-      let result = try swiftRun(
+  func testWithDebugInfo() async throws {
+    try await withFixture("EchoExecutable") { packageDirectory in
+      let result = try await swiftRun(
         ["carton", "bundle", "--debug-info"], packageDirectory: packageDirectory.url
       )
-      result.assertZeroExit()
+      try result.checkNonZeroExit()
 
       let bundleDirectory = packageDirectory.appending(component: "Bundle")
       guard let wasmBinary = (bundleDirectory.ls().filter { $0.contains("wasm") }).first else {
         XCTFail("No wasm binary found")
         return
       }
-      let headers = try Process.checkNonZeroExit(arguments: [
+      let headers = try await Process.checkNonZeroExit(arguments: [
         "wasm-objdump", "--headers", bundleDirectory.appending(component: wasmBinary).pathString,
       ])
       XCTAssert(headers.contains("\"name\""), "name section not found: \(headers)")
     }
   }
 
-  func testWithoutContentHash() throws {
-    try withFixture("EchoExecutable") { packageDirectory in
-      let result = try swiftRun(
+  func testWithoutContentHash() async throws {
+    try await withFixture("EchoExecutable") { packageDirectory in
+      let result = try await swiftRun(
         ["carton", "bundle", "--no-content-hash", "--wasm-optimizations", "none"], packageDirectory: packageDirectory.url
       )
-      result.assertZeroExit()
+      try result.checkNonZeroExit()
 
       let bundleDirectory = packageDirectory.appending(component: "Bundle")
       guard let wasmBinary = (bundleDirectory.ls().filter { $0.contains("wasm") }).first else {
@@ -76,16 +77,16 @@ final class BundleCommandTests: XCTestCase {
     }
   }
 
-  func testWasmOptimizationOptions() throws {
-    try withFixture("EchoExecutable") { packageDirectory in
-      func getFileSizeOfWasmBinary(wasmOptimizations: WasmOptimizations) throws -> UInt64 {
+  func testWasmOptimizationOptions() async throws {
+    try await withFixture("EchoExecutable") { packageDirectory in
+      func getFileSizeOfWasmBinary(wasmOptimizations: WasmOptimizations) async throws -> UInt64 {
         let bundleDirectory = packageDirectory.appending(component: "Bundle")
 
-        let result = try swiftRun(
+        let result = try await swiftRun(
           ["carton", "bundle", "--wasm-optimizations", wasmOptimizations.rawValue],
           packageDirectory: packageDirectory.url
         )
-        result.assertZeroExit()
+        try result.checkNonZeroExit()
 
         guard let wasmFile = (bundleDirectory.ls().filter { $0.contains("wasm") }).first else {
           XCTFail("No wasm binary found")
@@ -95,10 +96,9 @@ final class BundleCommandTests: XCTestCase {
         return try localFileSystem.getFileInfo(bundleDirectory.appending(component: wasmFile)).size
       }
 
-      try XCTAssertGreaterThan(
-        getFileSizeOfWasmBinary(wasmOptimizations: .none),
-        getFileSizeOfWasmBinary(wasmOptimizations: .size)
-      )
+      let none = try await getFileSizeOfWasmBinary(wasmOptimizations: .none)
+      let optimized = try await getFileSizeOfWasmBinary(wasmOptimizations: .size)
+      XCTAssertGreaterThan(none, optimized)
     }
   }
 }

--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -31,7 +31,7 @@ final class DevCommandTests: XCTestCase {
     func testWithNoArguments() async throws {
       // FIXME: Don't assume a specific port is available since it can be used by others or tests
       try await withFixture("EchoExecutable") { packageDirectory in
-        let (process, _, _) = try swiftRunProcess(
+        let process = try swiftRunProcess(
           ["carton", "dev", "--verbose", "--skip-auto-open"],
           packageDirectory: packageDirectory.url
         )
@@ -43,7 +43,7 @@ final class DevCommandTests: XCTestCase {
     func testWithArguments() async throws {
       // FIXME: Don't assume a specific port is available since it can be used by others or tests
       try await withFixture("EchoExecutable") { packageDirectory in
-        let (process, _, _) = try swiftRunProcess(
+        let process = try swiftRunProcess(
           ["carton", "dev", "--verbose", "--port", "8081", "--skip-auto-open"],
           packageDirectory: packageDirectory.url
         )
@@ -53,7 +53,7 @@ final class DevCommandTests: XCTestCase {
     }
   #endif
 
-  func checkForExpectedContent(process: Process, at url: String) async {
+  func checkForExpectedContent(process: SwiftRunProcess, at url: String) async {
     // client time out for connecting and responding
     let timeOut: Int64 = 60
 
@@ -85,11 +85,6 @@ final class DevCommandTests: XCTestCase {
 
     // give the server some time to start
     repeat {
-      // Don't wait for anything if the process is dead.
-      guard process.isRunning else {
-        break
-      }
-
       sleep(delay)
       count += 1
 
@@ -109,7 +104,7 @@ final class DevCommandTests: XCTestCase {
     } while count < polls && response == nil
 
     // end the process regardless of success
-    process.terminate()
+    process.process.signal(SIGTERM)
 
     if let response = response {
       XCTAssertTrue(response.statusCode == 200, "Response was not ok")


### PR DESCRIPTION
#458 と同じ目的を、別のアプローチで実装します。

ストリームとキャプチャを同時にするために、
`Foundation.Process` を利用しているところを変更し、
`CartonHelpers.Process` を使うようにします。

これには `outputRedirection:` という機能があるため、
これを活用してクロージャでデータフローを実装します。