### PR TITLE
TSC.Processの実装内部のdeprecated警告を潰す

### DIFF
--- a/Sources/CartonHelpers/Basics/Process/Process.swift
+++ b/Sources/CartonHelpers/Basics/Process/Process.swift
@@ -270,8 +270,7 @@ public final class Process {
     private static let loggingHandlerLock = NSLock()
 
     /// Global logging handler. Use with care! preferably use instance level instead of setting one globally.
-    @available(*, deprecated, message: "use instance level `loggingHandler` passed via `init` instead of setting one globally.")
-    public static var loggingHandler: LoggingHandler? {
+    private static var loggingHandler: LoggingHandler? {
         get {
             Self.loggingHandlerLock.withLock {
                 self._loggingHandler
@@ -295,8 +294,7 @@ public final class Process {
     public let arguments: [String]
 
     /// The environment with which the process was executed.
-    @available(*, deprecated, message: "use `environmentBlock` instead")
-    public var environment: [String:String] {
+    private var environment: [String:String] {
         Dictionary<String, String>(uniqueKeysWithValues: environmentBlock.map { ($0.key.value, $0.value) })
     }
 


### PR DESCRIPTION
#460 の変更によって、 `CartonHelpers.Process` をコンパイルするときに警告が出るようになってしまいました。
外向けに deprecated 指定されているAPIを、実装内部で使用しているからです。

これは本来は TSC.Process のユーザがそのAPIを触れるのをやめさせるための警告で、
Cartonにおいてコピペしてきた実装が内部で生じさせる警告は不要です。

そこで、deprecated指定を外しつつ、
そのAPIを public から private にします。
これでCartonから触ることがなくなるので、
実質的にdeprecated警告を遵守できます。