### PR TITLE
`createWSHandler` をリネームする

### DIFF
--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -240,7 +240,7 @@ public actor Server {
             ?? .other
           let handler = await ServerWebSocketHandler(
             configuration: ServerWebSocketHandler.Configuration(
-              onText: self.createWSHandler(in: environment, terminal: self.configuration.terminal)
+              onText: self.createWebSocketTextHandler(in: environment, terminal: self.configuration.terminal)
             )
           )
           await self.add(connection: Connection(channel: channel))
@@ -330,7 +330,7 @@ public actor Server {
 
 extension Server {
   /// Returns a handler that responds to WebSocket messages coming from the browser.
-  func createWSHandler(
+  func createWebSocketTextHandler(
     in environment: DestinationEnvironment,
     terminal: InteractiveWriter
   ) -> @Sendable (String) -> Void {


### PR DESCRIPTION
`Server.createWSHandler` というメソッドがあります。
一見 WebSocketHandler を作るメソッドに見えます。

しかし、`Server` における `WebSocketHandler` とは、
swift-nio の `ChannelInboundHandler` である `ServerWebSocketHandler` 型のことです。

このメソッドが返すのはただの `String` の consumer で、
上記のハンドラ型とは違うものです。

実際にはこれがハンドラに渡されて、
WebSocketのtextメッセージが来た時のコールバック処理を定義しています。
これは `onText:` というラベルを通して設定されます。

そこで、 このメソッドを `createWebSocketTextHandler` に変更します。

`createTextHandler` にしたいところでしたが、
`Server` は `ServerHTTPHandler` も面倒を見ていて、
そちらのテキスト処理とも曖昧になりうるので、
フルの修飾が必要です。