### PR TITLE
Remove test utility `ls`

### DIFF
--- a/Tests/CartonCommandTests/Testable.swift
+++ b/Tests/CartonCommandTests/Testable.swift
@@ -56,11 +56,3 @@ func withFixture(_ name: String, _ body: (AbsolutePath) async throws -> Void) as
   let fixtureDir = try testFixturesDirectory.appending(component: name)
   try await body(fixtureDir)
 }
-
-extension AbsolutePath {
-  func ls() -> [String] {
-    guard let paths = try? FileManager.default.subpathsOfDirectory(atPath: pathString)
-    else { return [] }
-    return paths
-  }
-}


### PR DESCRIPTION
`AbsolutePath.ls` をしなくても、 `FileSystem.getDirectoryContents` や `FileSystem.traverseRecursively` があります。
テスト用のやり方を用意してもコード短縮の恩恵は少ないです。

また、 `ls` という名前なのに再帰的に中身を取り出す挙動は予測しづらいです。

必要ない道具は消したほうが、コードベースを把握しやすくなります。

また、 `ls` は `String` を返しますが、
ここではファイルパスであることが確定しているので、
`AbsolutePath` を返すAPIの方が、
その先のデータ操作で様々なメソッドが使えて便利です。

使わなくても十分に整ったテストが書けるので消します。

#468 でもこの件に少し触れています。