### PR TITLE
Add granular configuration for retrying wait time in test

### DIFF
--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -62,7 +62,7 @@ final class DevCommandTests: XCTestCase {
     let count = 5
 
     do {
-      return try await withRetry(maxAttempts: count, delay: delay) {
+      return try await withRetry(maxAttempts: count, initialDelay: delay, retryInterval: delay) {
         try await fetchWebContent(at: url, timeout: timeOut)
       }
     } catch {

--- a/Tests/CartonCommandTests/FrontendDevServerTests.swift
+++ b/Tests/CartonCommandTests/FrontendDevServerTests.swift
@@ -41,12 +41,16 @@ final class FrontendDevServerTests: XCTestCase {
     defer {
       devServer.signal(SIGINT)
     }
-    try await Task.sleep(for: .seconds(3))
 
     let host = try URL(string: "http://127.0.0.1:8080").unwrap("url")
 
     do {
-      let indexHtml = try await fetchString(at: host)
+      let indexHtml = try await withRetry(
+        maxAttempts: 5, initialDelay: .seconds(3), retryInterval: .seconds(10)
+      ) {
+        try await fetchString(at: host)
+      }
+
       XCTAssertEqual(indexHtml, """
         <!DOCTYPE html>
         <html>


### PR DESCRIPTION
以下でCIがこけました
https://github.com/swiftwasm/carton/pull/469#issuecomment-2124942557

おそらくタイミング問題で、サーバが立ち上がっていなかっただけなので、
待ってからリトライすれば直ります。

ここで、最初の待ち時間は短くして、
失敗しとの待ち時間は長くしたいです。

そこで既存の `withRetry` を改善して指定できるようにします。