### PR TITLE
Combine the WebDriver setup process into WebDriverService and make it easier to reuse

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -149,7 +149,13 @@ let package = Package(
       name: "CartonCore",
       exclude: ["README.md"]
     ),
-    .target(name: "WebDriver", dependencies: []),
+    .target(
+      name: "WebDriver",
+      dependencies: [
+        .product(name: "NIO", package: "swift-nio"),
+        "CartonHelpers"
+      ]
+    ),
     // This target is used only for release automation tasks and
     // should not be installed by `carton` users.
     .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -113,7 +113,7 @@ let package = Package(
         .product(name: "NIO", package: "swift-nio"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         "CartonHelpers",
-        "WebDriverClient",
+        "WebDriver",
         "WasmTransformer",
       ],
       exclude: ["Utilities/README.md"]
@@ -149,7 +149,7 @@ let package = Package(
       name: "CartonCore",
       exclude: ["README.md"]
     ),
-    .target(name: "WebDriverClient", dependencies: []),
+    .target(name: "WebDriver", dependencies: []),
     // This target is used only for release automation tasks and
     // should not be installed by `carton` users.
     .executableTarget(
@@ -176,6 +176,6 @@ let package = Package(
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),
-    .testTarget(name: "WebDriverClientTests", dependencies: ["WebDriverClient"]),
+    .testTarget(name: "WebDriverTests", dependencies: ["WebDriver"]),
   ]
 )

--- a/Sources/CartonFrontend/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonFrontend/Commands/TestRunners/BrowserTestRunner.swift
@@ -17,7 +17,7 @@ import CartonKit
 import Foundation
 import NIOCore
 import NIOPosix
-import WebDriverClient
+import WebDriver
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking
@@ -139,8 +139,7 @@ struct BrowserTestRunner: TestRunner {
     var retries = 0
     while true {
       do {
-        return try await WebDriverClient.newSession(
-          endpoint: endpoint, httpClient: URLSession.shared)
+        return try await WebDriverClient.newSession(endpoint: endpoint)
       } catch {
         if retries >= maxRetries {
           throw error

--- a/Sources/CartonHelpers/Retry.swift
+++ b/Sources/CartonHelpers/Retry.swift
@@ -1,0 +1,25 @@
+public func withRetry<R>(
+  maxAttempts: Int,
+  initialDelay: Duration,
+  retryInterval: Duration,
+  body: () async throws -> R
+) async throws -> R {
+  try await Task.sleep(for: initialDelay)
+
+  var attempt = 0
+  while true {
+    attempt += 1
+    do {
+      return try await body()
+    } catch {
+      if attempt < maxAttempts {
+        print("attempt \(attempt) failed: \(error), retrying...")
+
+        try await Task.sleep(for: retryInterval)
+        continue
+      }
+
+      throw error
+    }
+  }
+}

--- a/Sources/CartonHelpers/Retry.swift
+++ b/Sources/CartonHelpers/Retry.swift
@@ -13,7 +13,7 @@ public func withRetry<R>(
       return try await body()
     } catch {
       if attempt < maxAttempts {
-        print("attempt \(attempt) failed: \(error), retrying...")
+        print("attempt \(attempt)/\(maxAttempts) failed: \(error), retrying in \(retryInterval)...")
 
         try await Task.sleep(for: retryInterval)
         continue

--- a/Sources/WebDriver/CommandWebDriverService.swift
+++ b/Sources/WebDriver/CommandWebDriverService.swift
@@ -1,0 +1,90 @@
+import CartonHelpers
+import Foundation
+import NIOCore
+import NIOPosix
+
+public struct CommandWebDriverService: WebDriverService {
+  private static func findAvailablePort() async throws -> SocketAddress {
+    let bootstrap = ServerBootstrap(group: .singletonMultiThreadedEventLoopGroup)
+    let address = try SocketAddress.makeAddressResolvingHost("127.0.0.1", port: 0)
+    let channel = try await bootstrap.bind(to: address).get()
+    let localAddr = channel.localAddress!
+    try await channel.close()
+    return localAddr
+  }
+
+  private static func launchDriver(
+    terminal: InteractiveWriter,
+    executablePath: String
+  ) async throws -> (URL, CartonHelpers.Process) {
+    let address = try await findAvailablePort()
+    let process = CartonHelpers.Process(arguments: [
+      executablePath, "--port=\(address.port!)",
+    ])
+    terminal.logLookup("Launch WebDriver executable: ", executablePath)
+    try process.launch()
+    let url = URL(string: "http://\(address.ipAddress!):\(address.port!)")!
+    return (url, process)
+  }
+
+  public static func findFromEnvironment(
+    terminal: CartonHelpers.InteractiveWriter
+  ) async throws -> CommandWebDriverService? {
+    terminal.logLookup("- checking WebDriver executable: ", "WEBDRIVER_PATH")
+    guard let executable = ProcessInfo.processInfo.environment["WEBDRIVER_PATH"] else {
+      return nil
+    }
+    let (endpoint, process) = try await launchDriver(
+      terminal: terminal, executablePath: executable
+    )
+    return CommandWebDriverService(endpoint: endpoint, process: process)
+  }
+
+  public static func findFromPath(
+    terminal: CartonHelpers.InteractiveWriter
+  ) async throws -> CommandWebDriverService? {
+    let driverCandidates = [
+      "chromedriver", "geckodriver", "safaridriver", "msedgedriver",
+    ]
+    terminal.logLookup(
+      "- checking WebDriver executable in PATH: ", driverCandidates.joined(separator: ", "))
+    guard let found = driverCandidates.lazy
+      .compactMap({ CartonHelpers.Process.findExecutable($0) }).first else
+    {
+      return nil
+    }
+    let (endpoint, process) = try await launchDriver(
+      terminal: terminal, executablePath: found.pathString
+    )
+    return CommandWebDriverService(endpoint: endpoint, process: process)
+  }
+
+  public static func find(
+    terminal: CartonHelpers.InteractiveWriter
+  ) async throws -> CommandWebDriverService? {
+    if let driver = try await findFromEnvironment(terminal: terminal) {
+      return driver
+    }
+
+    if let driver = try await findFromPath(terminal: terminal) {
+      return driver
+    }
+
+    return nil
+  }
+  
+  public init(
+    endpoint: URL,
+    process: CartonHelpers.Process
+  ) {
+    self.endpoint = endpoint
+    self.process = process
+  }
+
+  public var endpoint: URL
+  public var process: CartonHelpers.Process
+
+  public func dispose() {
+    process.signal(SIGKILL)
+  }
+}

--- a/Sources/WebDriver/CurlWebDriverHTTPClient.swift
+++ b/Sources/WebDriver/CurlWebDriverHTTPClient.swift
@@ -14,6 +14,10 @@
 
 import Foundation
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 public struct CurlWebDriverHTTPClient: WebDriverHTTPClient {
   public init(cliPath: URL) {
     self.cliPath = cliPath

--- a/Sources/WebDriver/CurlWebDriverHTTPClient.swift
+++ b/Sources/WebDriver/CurlWebDriverHTTPClient.swift
@@ -1,0 +1,67 @@
+// Copyright 2022 Carton contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+public struct CurlWebDriverHTTPClient: WebDriverHTTPClient {
+  public init(cliPath: URL) {
+    self.cliPath = cliPath
+  }
+
+  public var cliPath: URL
+
+  public static func find() -> CurlWebDriverHTTPClient? {
+    guard let path = ProcessInfo.processInfo.environment["PATH"] else { return nil }
+    #if os(Windows)
+    let pathSeparator: Character = ";"
+    #else
+    let pathSeparator: Character = ":"
+    #endif
+    for pathEntry in path.split(separator: pathSeparator) {
+      let candidate = URL(fileURLWithPath: String(pathEntry)).appendingPathComponent("curl")
+      if FileManager.default.fileExists(atPath: candidate.path) {
+        return CurlWebDriverHTTPClient(cliPath: candidate)
+      }
+    }
+    return nil
+  }
+
+  public func data(for request: URLRequest) async throws -> Data {
+    guard let url = request.url?.absoluteString else {
+      preconditionFailure()
+    }
+    let process = Process()
+    process.executableURL = cliPath
+    process.arguments = [
+      url, "-X", request.httpMethod ?? "GET", "--silent", "--fail-with-body", "--data-binary", "@-"
+    ]
+    let stdout = Pipe()
+    let stdin = Pipe()
+    process.standardOutput = stdout
+    process.standardInput = stdin
+    if let httpBody = request.httpBody {
+      try stdin.fileHandleForWriting.write(contentsOf: httpBody)
+    }
+    try stdin.fileHandleForWriting.close()
+    try process.run()
+    process.waitUntilExit()
+    let responseBody = try stdout.fileHandleForReading.readToEnd()
+    guard process.terminationStatus == 0 else {
+      throw WebDriverError.httpError(
+        responseBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+      )
+    }
+    return responseBody ?? Data()
+  }
+}

--- a/Sources/WebDriver/CurlWebDriverHTTPClient.swift
+++ b/Sources/WebDriver/CurlWebDriverHTTPClient.swift
@@ -58,8 +58,12 @@ public struct CurlWebDriverHTTPClient: WebDriverHTTPClient {
     process.waitUntilExit()
     let responseBody = try stdout.fileHandleForReading.readToEnd()
     guard process.terminationStatus == 0 else {
-      throw WebDriverError.httpError(
-        responseBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+      let body: String? = responseBody.map { String(decoding: $0, as: UTF8.self) }
+
+      throw WebDriverError.curlError(
+        path: cliPath, 
+        status: process.terminationStatus,
+        body: body
       )
     }
     return responseBody ?? Data()

--- a/Sources/WebDriver/RemoteWebDriverService.swift
+++ b/Sources/WebDriver/RemoteWebDriverService.swift
@@ -1,0 +1,25 @@
+import CartonHelpers
+import Foundation
+
+public struct RemoteWebDriverService: WebDriverService {
+  public static func find(
+    terminal: InteractiveWriter
+  ) async throws -> RemoteWebDriverService? {
+    terminal.logLookup("- checking WebDriver endpoint: ", "WEBDRIVER_REMOTE_URL")
+    guard let value = ProcessInfo.processInfo.environment["WEBDRIVER_REMOTE_URL"] else {
+      return nil
+    }
+    guard let endporint = URL(string: value) else {
+      throw WebDriverError.invalidRemoteURL(value)
+    }
+    return RemoteWebDriverService(endpoint: endporint)
+  }
+
+  public init(endpoint: URL) {
+    self.endpoint = endpoint
+  }
+
+  public var endpoint: URL
+
+  public func dispose() {}
+}

--- a/Sources/WebDriver/URLSessionAsync.swift
+++ b/Sources/WebDriver/URLSessionAsync.swift
@@ -1,0 +1,35 @@
+// Copyright 2022 Carton contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(FoundationNetworking)
+
+import FoundationNetworking
+
+/// Until we get "async" implementations of URLSession in corelibs-foundation, we use our own polyfill.
+extension URLSession {
+  public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+    return try await withCheckedThrowingContinuation { continuation in
+      let task = self.dataTask(with: request) { (data, response, error) in
+        guard let data = data, let response = response else {
+          let error = error ?? URLError(.badServerResponse)
+          return continuation.resume(throwing: error)
+        }
+        continuation.resume(returning: (data, response))
+      }
+      task.resume()
+    }
+  }
+}
+
+#endif

--- a/Sources/WebDriver/URLSessionAsync.swift
+++ b/Sources/WebDriver/URLSessionAsync.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Foundation
+
 #if canImport(FoundationNetworking)
 
 import FoundationNetworking

--- a/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
+++ b/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
@@ -18,6 +18,11 @@ import Foundation
 import FoundationNetworking
 #endif
 
+#if os(Linux)
+
+#else
+
+// Due to a broken URLSession in swift-corelibs-foundation, this class cannot be used on Linux.
 public struct URLSessionWebDriverHTTPClient: WebDriverHTTPClient {
   public init(session: URLSession) {
     self.session = session
@@ -36,3 +41,5 @@ public struct URLSessionWebDriverHTTPClient: WebDriverHTTPClient {
     return data
   }
 }
+
+#endif

--- a/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
+++ b/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
@@ -15,7 +15,6 @@
 import Foundation
 
 #if canImport(FoundationNetworking)
-import FoundationNetworking
 #else
 
 // Due to a broken URLSession in swift-corelibs-foundation, this class cannot be used on Linux.

--- a/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
+++ b/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
@@ -1,0 +1,38 @@
+// Copyright 2022 Carton contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct URLSessionWebDriverHTTPClient: WebDriverHTTPClient {
+  public init(session: URLSession) {
+    self.session = session
+  }
+
+  public var session: URLSession
+
+  public func data(for request: URLRequest) async throws -> Data {
+    let (data, httpResponse) = try await session.data(for: request)
+    guard let httpResponse = httpResponse as? HTTPURLResponse, 200..<300 ~= httpResponse.statusCode
+    else {
+      throw WebDriverError.httpError(
+        "\(request.httpMethod ?? "GET") \(request.url.debugDescription) failed"
+      )
+    }
+    return data
+  }
+}

--- a/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
+++ b/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
@@ -16,9 +16,6 @@ import Foundation
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking
-#endif
-
-#if canImport(FoundationNetworking)
 #else
 
 // Due to a broken URLSession in swift-corelibs-foundation, this class cannot be used on Linux.

--- a/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
+++ b/Sources/WebDriver/URLSessionWebDriverHTTPClient.swift
@@ -18,8 +18,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-#if os(Linux)
-
+#if canImport(FoundationNetworking)
 #else
 
 // Due to a broken URLSession in swift-corelibs-foundation, this class cannot be used on Linux.

--- a/Sources/WebDriver/WebDriverClient.swift
+++ b/Sources/WebDriver/WebDriverClient.swift
@@ -15,31 +15,11 @@
 import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
-
-  /// Until we get "async" implementations of URLSession in corelibs-foundation, we use our own polyfill.
-  extension URLSession {
-    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-      return try await withCheckedThrowingContinuation { continuation in
-        let task = self.dataTask(with: request) { (data, response, error) in
-          guard let data = data, let response = response else {
-            let error = error ?? URLError(.badServerResponse)
-            return continuation.resume(throwing: error)
-          }
-          continuation.resume(returning: (data, response))
-        }
-        task.resume()
-      }
-    }
-  }
+import FoundationNetworking
 #endif
 
-public enum WebDriverError: Error {
-  case httpError(String)
-}
-
 public struct WebDriverClient {
-  private let client: WebDriverHTTPClient
+  private let client: any WebDriverHTTPClient
   let driverEndpoint: URL
   let sessionId: String
 
@@ -71,8 +51,9 @@ public struct WebDriverClient {
     """#
 
   public static func newSession(
-    endpoint: URL, body: String = defaultSessionRequestBody,
-    httpClient: URLSession
+    endpoint: URL, 
+    body: String = defaultSessionRequestBody,
+    httpClient: (any WebDriverHTTPClient)? = nil
   ) async throws -> WebDriverClient {
     struct Response: Decodable {
       let sessionId: String
@@ -81,7 +62,10 @@ public struct WebDriverClient {
       let capabilities: [String: String] = [:]
       let desiredCapabilities: [String: String] = [:]
     }
-    let httpClient: WebDriverHTTPClient = Curl.findExecutable() ?? httpClient
+    let httpClient = httpClient ??
+      CurlWebDriverHTTPClient.find() ??
+      URLSessionWebDriverHTTPClient(session: .shared)
+    
     var request = URLRequest(url: endpoint.appendingPathComponent("session"))
     request.httpMethod = "POST"
     request.httpBody = body.data(using: .utf8)
@@ -125,71 +109,5 @@ public struct WebDriverClient {
     var request = URLRequest(url: URL(string: makeSessionURL())!)
     request.httpMethod = "DELETE"
     _ = try await client.data(for: request)
-  }
-}
-
-
-private protocol WebDriverHTTPClient {
-  func data(for request: URLRequest) async throws -> Data
-}
-
-extension URLSession: WebDriverHTTPClient {
-  func data(for request: URLRequest) async throws -> Data {
-    let (data, httpResponse) = try await self.data(for: request)
-    guard let httpResponse = httpResponse as? HTTPURLResponse, 200..<300 ~= httpResponse.statusCode
-    else {
-      throw WebDriverError.httpError(
-        "\(request.httpMethod ?? "GET") \(request.url.debugDescription) failed"
-      )
-    }
-    return data
-  }
-}
-
-private struct Curl: WebDriverHTTPClient {
-  let cliPath: URL
-
-  static func findExecutable() -> Curl? {
-    guard let path = ProcessInfo.processInfo.environment["PATH"] else { return nil }
-    #if os(Windows)
-    let pathSeparator: Character = ";"
-    #else
-    let pathSeparator: Character = ":"
-    #endif
-    for pathEntry in path.split(separator: pathSeparator) {
-      let candidate = URL(fileURLWithPath: String(pathEntry)).appendingPathComponent("curl")
-      if FileManager.default.fileExists(atPath: candidate.path) {
-        return Curl(cliPath: candidate)
-      }
-    }
-    return nil
-  }
-
-  func data(for request: URLRequest) async throws -> Data {
-    guard let url = request.url?.absoluteString else {
-      preconditionFailure()
-    }
-    let process = Process()
-    process.executableURL = cliPath
-    process.arguments = [
-      url, "-X", request.httpMethod ?? "GET", "--silent", "--fail-with-body", "--data-binary", "@-"
-    ]
-    let stdout = Pipe()
-    let stdin = Pipe()
-    process.standardOutput = stdout
-    process.standardInput = stdin
-    if let httpBody = request.httpBody {
-      try stdin.fileHandleForWriting.write(contentsOf: httpBody)
-    }
-    try stdin.fileHandleForWriting.close()
-    try process.run()
-    process.waitUntilExit()
-    let responseBody = try stdout.fileHandleForReading.readToEnd()
-    guard process.terminationStatus == 0 else {
-      throw WebDriverError.httpError(
-        responseBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
-      )
-    }
-    return responseBody ?? Data()
   }
 }

--- a/Sources/WebDriver/WebDriverClient.swift
+++ b/Sources/WebDriver/WebDriverClient.swift
@@ -53,7 +53,7 @@ public struct WebDriverClient {
   public static func newSession(
     endpoint: URL, 
     body: String = defaultSessionRequestBody,
-    httpClient: (any WebDriverHTTPClient)? = nil
+    httpClient: any WebDriverHTTPClient
   ) async throws -> WebDriverClient {
     struct Response: Decodable {
       let sessionId: String
@@ -62,9 +62,6 @@ public struct WebDriverClient {
       let capabilities: [String: String] = [:]
       let desiredCapabilities: [String: String] = [:]
     }
-    let httpClient = httpClient ??
-      CurlWebDriverHTTPClient.find() ??
-      URLSessionWebDriverHTTPClient(session: .shared)
     
     var request = URLRequest(url: endpoint.appendingPathComponent("session"))
     request.httpMethod = "POST"

--- a/Sources/WebDriver/WebDriverError.swift
+++ b/Sources/WebDriver/WebDriverError.swift
@@ -14,6 +14,36 @@
 
 import Foundation
 
-public enum WebDriverError: Error {
+public enum WebDriverError: Error & CustomStringConvertible {
+  case invalidRemoteURL(String)
+  case failedToFindWebDriver
+  case curlError(path: URL, status: Int32, body: String?)
   case httpError(String)
+
+  public var description: String {
+    switch self {
+    case .invalidRemoteURL(let url): return "invalid remote webdriver URL: \(url)"
+    case .curlError(path: let path, status: let status, body: let body):
+      var lines: [String] = [
+        "curl command at \(path.path) failed with status \(status)."
+      ]
+
+      if let body {
+        lines += [
+          "body:", body
+        ]
+      }
+
+      return lines.joined(separator: "\n")
+    case .failedToFindWebDriver:
+      return """
+      Failed to find WebDriver executable or remote URL to a running driver process.
+      Please make sure that you are satisfied with one of the followings (in order of priority)
+      1. Set `WEBDRIVER_REMOTE_URL` with the address of remote WebDriver like `WEBDRIVER_REMOTE_URL=http://localhost:9515`.
+      2. Set `WEBDRIVER_PATH` with the path to your WebDriver executable.
+      3. `chromedriver`, `geckodriver`, `safaridriver`, or `msedgedriver` has been installed in `PATH`
+      """
+    case .httpError(let string): return "http error: \(string)"
+    }
+  }
 }

--- a/Sources/WebDriver/WebDriverError.swift
+++ b/Sources/WebDriver/WebDriverError.swift
@@ -1,0 +1,19 @@
+// Copyright 2022 Carton contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+public enum WebDriverError: Error {
+  case httpError(String)
+}

--- a/Sources/WebDriver/WebDriverError.swift
+++ b/Sources/WebDriver/WebDriverError.swift
@@ -25,7 +25,7 @@ public enum WebDriverError: Error & CustomStringConvertible {
     case .invalidRemoteURL(let url): return "invalid remote webdriver URL: \(url)"
     case .curlError(path: let path, status: let status, body: let body):
       var lines: [String] = [
-        "curl command at \(path.path) failed with status \(status)."
+        "\(path.path) failed with status \(status)."
       ]
 
       if let body {

--- a/Sources/WebDriver/WebDriverError.swift
+++ b/Sources/WebDriver/WebDriverError.swift
@@ -17,6 +17,7 @@ import Foundation
 public enum WebDriverError: Error & CustomStringConvertible {
   case invalidRemoteURL(String)
   case failedToFindWebDriver
+  case failedToFindHTTPClient
   case curlError(path: URL, status: Int32, body: String?)
   case httpError(String)
 
@@ -42,6 +43,13 @@ public enum WebDriverError: Error & CustomStringConvertible {
       1. Set `WEBDRIVER_REMOTE_URL` with the address of remote WebDriver like `WEBDRIVER_REMOTE_URL=http://localhost:9515`.
       2. Set `WEBDRIVER_PATH` with the path to your WebDriver executable.
       3. `chromedriver`, `geckodriver`, `safaridriver`, or `msedgedriver` has been installed in `PATH`
+      """
+    case .failedToFindHTTPClient:
+      return """
+      The HTTPClient for use with WebDriver could not be found.
+      On Linux, please ensure that curl is installed.
+      On Mac, URLSession can be used, so this error should not appear.
+      If this error is displayed, an unknown bug may have occurred.
       """
     case .httpError(let string): return "http error: \(string)"
     }

--- a/Sources/WebDriver/WebDriverHTTPClient.swift
+++ b/Sources/WebDriver/WebDriverHTTPClient.swift
@@ -1,0 +1,19 @@
+// Copyright 2022 Carton contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+public protocol WebDriverHTTPClient {
+  func data(for request: URLRequest) async throws -> Data
+}

--- a/Sources/WebDriver/WebDriverHTTPClient.swift
+++ b/Sources/WebDriver/WebDriverHTTPClient.swift
@@ -17,3 +17,13 @@ import Foundation
 public protocol WebDriverHTTPClient {
   func data(for request: URLRequest) async throws -> Data
 }
+
+public enum WebDriverHTTPClients {
+  public static func find() -> any WebDriverHTTPClient {
+    if let curl = CurlWebDriverHTTPClient.find() {
+      return curl
+    }
+
+    return URLSessionWebDriverHTTPClient(session: .shared)
+  }
+}

--- a/Sources/WebDriver/WebDriverHTTPClient.swift
+++ b/Sources/WebDriver/WebDriverHTTPClient.swift
@@ -14,6 +14,10 @@
 
 import Foundation
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 public protocol WebDriverHTTPClient {
   func data(for request: URLRequest) async throws -> Data
 }

--- a/Sources/WebDriver/WebDriverHTTPClient.swift
+++ b/Sources/WebDriver/WebDriverHTTPClient.swift
@@ -28,11 +28,10 @@ public enum WebDriverHTTPClients {
       return curl
     }
 
-    #if os(Linux)
+    #if canImport(FoundationNetworking)
+    throw WebDriverError.failedToFindHTTPClient
     #else
     return URLSessionWebDriverHTTPClient(session: .shared)
     #endif
-
-    throw WebDriverError.failedToFindHTTPClient
   }
 }

--- a/Sources/WebDriver/WebDriverHTTPClient.swift
+++ b/Sources/WebDriver/WebDriverHTTPClient.swift
@@ -23,11 +23,16 @@ public protocol WebDriverHTTPClient {
 }
 
 public enum WebDriverHTTPClients {
-  public static func find() -> any WebDriverHTTPClient {
+  public static func find() throws -> any WebDriverHTTPClient {
     if let curl = CurlWebDriverHTTPClient.find() {
       return curl
     }
 
+    #if os(Linux)
+    #else
     return URLSessionWebDriverHTTPClient(session: .shared)
+    #endif
+
+    throw WebDriverError.failedToFindHTTPClient
   }
 }

--- a/Sources/WebDriver/WebDriverService.swift
+++ b/Sources/WebDriver/WebDriverService.swift
@@ -17,7 +17,11 @@ extension WebDriverService {
   ) async throws -> WebDriverClient {
     let httpClient = httpClient ?? WebDriverHTTPClients.find()
 
-    return try await withRetry(maxAttempts: 3, initialDelay: .zero, retryInterval: .seconds(1)) {
+    return try await withRetry(
+      maxAttempts: 5,
+      initialDelay: .seconds(3),
+      retryInterval: .seconds(10)
+    ) {
       try await WebDriverClient.newSession(
         endpoint: endpoint,
         httpClient: httpClient

--- a/Sources/WebDriver/WebDriverService.swift
+++ b/Sources/WebDriver/WebDriverService.swift
@@ -15,7 +15,7 @@ extension WebDriverService {
   public func client(
     httpClient: (any WebDriverHTTPClient)? = nil
   ) async throws -> WebDriverClient {
-    let httpClient = httpClient ?? WebDriverHTTPClients.find()
+    let httpClient = try httpClient ?? WebDriverHTTPClients.find()
 
     return try await withRetry(
       maxAttempts: 5,

--- a/Sources/WebDriver/WebDriverService.swift
+++ b/Sources/WebDriver/WebDriverService.swift
@@ -1,0 +1,43 @@
+import CartonHelpers
+import Foundation
+
+public protocol WebDriverService {
+  static func find(
+    terminal: InteractiveWriter
+  ) async throws -> Self?
+
+  func dispose()
+
+  var endpoint: URL { get }
+}
+
+extension WebDriverService {
+  public func client(
+    httpClient: (any WebDriverHTTPClient)? = nil
+  ) async throws -> WebDriverClient {
+    let httpClient = httpClient ?? WebDriverHTTPClients.find()
+
+    return try await withRetry(maxAttempts: 3, initialDelay: .zero, retryInterval: .seconds(1)) {
+      try await WebDriverClient.newSession(
+        endpoint: endpoint,
+        httpClient: httpClient
+      )
+    }
+  }
+}
+
+public enum WebDriverServices {
+  public static func find(
+    terminal: InteractiveWriter
+  ) async throws -> any WebDriverService {
+    if let service = try await RemoteWebDriverService.find(terminal: terminal) {
+      return service
+    }
+
+    if let service = try await CommandWebDriverService.find(terminal: terminal) {
+      return service
+    }
+
+    throw WebDriverError.failedToFindWebDriver
+  }
+}

--- a/Tests/CartonCommandTests/CommandTestHelper.swift
+++ b/Tests/CartonCommandTests/CommandTestHelper.swift
@@ -144,29 +144,3 @@ func fetchWebContent(at url: URL, timeout: Duration) async throws -> (response: 
 
   return (response: response, body: body)
 }
-
-func withRetry<R>(
-  maxAttempts: Int,
-  initialDelay: Duration,
-  retryInterval: Duration,
-  body: () async throws -> R
-) async throws -> R {
-  try await Task.sleep(for: initialDelay)
-
-  var attempt = 0
-  while true {
-    attempt += 1
-    do {
-      return try await body()
-    } catch {
-      if attempt < maxAttempts {
-        print("attempt \(attempt) failed: \(error), retrying...")
-
-        try await Task.sleep(for: retryInterval)
-        continue
-      }
-
-      throw error
-    }
-  }
-}

--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import XCTest
+import CartonHelpers
 
 @testable import CartonFrontend
 

--- a/Tests/WebDriverTests/WebDriverClientTests.swift
+++ b/Tests/WebDriverTests/WebDriverClientTests.swift
@@ -17,6 +17,8 @@ import WebDriver
 import XCTest
 
 final class WebDriverClientTests: XCTestCase {
+  #if os(Linux)
+  #else
   func testGotoURLSession() async throws {
     let terminal = InteractiveWriter.stdout
     let service = try await WebDriverServices.find(terminal: terminal)
@@ -30,6 +32,7 @@ final class WebDriverClientTests: XCTestCase {
     try await client.goto(url: "https://example.com")
     try await client.closeSession()
   }
+  #endif
 
   func testGotoCurl() async throws {
     let terminal = InteractiveWriter.stdout

--- a/Tests/WebDriverTests/WebDriverClientTests.swift
+++ b/Tests/WebDriverTests/WebDriverClientTests.swift
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import CartonHelpers
 import WebDriver
 import XCTest
 
 final class WebDriverClientTests: XCTestCase {
-  func checkRemoteURL() throws -> URL {
-    guard let value = ProcessInfo.processInfo.environment["WEBDRIVER_REMOTE_URL"] else {
-      throw XCTSkip("Skip WebDriver tests due to no WEBDRIVER_REMOTE_URL env var")
-    }
-    return try XCTUnwrap(URL(string: value), "Invalid URL string: \(value)")
-  }
-
   func testGotoURLSession() async throws {
-    let client = try await WebDriverClient.newSession(
-      endpoint: checkRemoteURL(), 
+    let terminal = InteractiveWriter.stdout
+    let service = try await WebDriverServices.find(terminal: terminal)
+    defer {
+      service.dispose()
+    }
+
+    let client = try await service.client(
       httpClient: URLSessionWebDriverHTTPClient(session: .shared)
     )
     try await client.goto(url: "https://example.com")
@@ -33,8 +32,13 @@ final class WebDriverClientTests: XCTestCase {
   }
 
   func testGotoCurl() async throws {
-    let client = try await WebDriverClient.newSession(
-      endpoint: checkRemoteURL(),
+    let terminal = InteractiveWriter.stdout
+    let service = try await WebDriverServices.find(terminal: terminal)
+    defer {
+      service.dispose()
+    }
+
+    let client = try await service.client(
       httpClient: try XCTUnwrap(CurlWebDriverHTTPClient.find())
     )
     try await client.goto(url: "https://example.com")

--- a/Tests/WebDriverTests/WebDriverClientTests.swift
+++ b/Tests/WebDriverTests/WebDriverClientTests.swift
@@ -17,7 +17,7 @@ import WebDriver
 import XCTest
 
 final class WebDriverClientTests: XCTestCase {
-  #if os(Linux)
+  #if canImport(FoundationNetworking)
   #else
   func testGotoURLSession() async throws {
     let terminal = InteractiveWriter.stdout

--- a/Tests/WebDriverTests/WebDriverClientTests.swift
+++ b/Tests/WebDriverTests/WebDriverClientTests.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import WebDriverClient
+import WebDriver
 import XCTest
 
 final class WebDriverClientTests: XCTestCase {
@@ -23,9 +23,19 @@ final class WebDriverClientTests: XCTestCase {
     return try XCTUnwrap(URL(string: value), "Invalid URL string: \(value)")
   }
 
-  func testGoto() async throws {
+  func testGotoURLSession() async throws {
     let client = try await WebDriverClient.newSession(
-      endpoint: checkRemoteURL(), httpClient: .shared
+      endpoint: checkRemoteURL(), 
+      httpClient: URLSessionWebDriverHTTPClient(session: .shared)
+    )
+    try await client.goto(url: "https://example.com")
+    try await client.closeSession()
+  }
+
+  func testGotoCurl() async throws {
+    let client = try await WebDriverClient.newSession(
+      endpoint: checkRemoteURL(),
+      httpClient: try XCTUnwrap(CurlWebDriverHTTPClient.find())
     )
     try await client.goto(url: "https://example.com")
     try await client.closeSession()


### PR DESCRIPTION
# 背景

#473 のために、WebDriver を利用したい。
WebDriver の実装は `WebDriverClient.swift` にクライアント実装、
`CartonFrontendTestCommand.swift` にドライバの選択処理などが書かれている。

# 提案

WebDriver関連の実装をモジュールにまとめて、
テストなどから再利用しやすいようにする。

## `WebDriverHTTPClient` の公開

`WebDriverClient` において、
curl が使える状況では 引数で受け取った `URLSession` を捨てるようになっていた。

また、 curl と URLSession の抽象化のために `WebDriverHTTPClient` を定義していた。
`URLSession` はこれに直接準拠していた。

`WebDriverClient` がHTTP通信に使う依存物は、
ユーザー側から注入をコントロールできるようにした方が良い。
そのほうが、個別の実装をテストしたり、
自動選択したりする挙動を使う意図が明確なコードを書くことができる。

しかし、 `WebDriverHTTPClient` のメソッドは、
`URLSession` の既存のメソッドと紛らわしいし、
仕様がこの用途に特化しているため、他の場所から使われたくないため、
`URLSession` への準拠させたくはない。

そこで、 `URLSessionWebDriverHTTPClient` というアダプタを用意する。
また、 `Curl` 型も `CurlWebDriverHTTPClient` にリネームする。

さらに、従来の選択挙動は `WebDriverHTTPClients.find` として利用可能にする。

## Linux の対応

`URLSessionWebDriverHTTPClient` は Linux では全く動かないことがわかった。
既存の実装も動いてなかったらしい。
そこで、これが動かないことをコメントしつつ、
`#if os` でLinuxでは完全に存在を消す。

以下で起票された。
https://github.com/apple/swift-corelibs-foundation/issues/4965

## `WebDriverService` の実装

`CartonFrontendTestCommand` において３種類のWebDriver利用パターンがあり、
そのうち2種類は終了時に専用のクリーンアップ処理が必要になっている。

そこで、この概念を `WebDriverService` として抽象化して、
3種類の実装を2つの具体型の `RemoteWebDriverService` と `CommandWebDriverService` として定義し直す。
`WebDriverService` はすでに起動した web driver を表現していて、
`dispose` メソッドでシャットダウンを行う。
また、(extensionで定義された) `client` メソッドに
`WebDriverHTTPClient` を渡すことで、
セッションの初期化が終了し通信できる状態になったクライアントを返す。

また、従来のドライバ選択ロジックは `WebDriverServices.find` として利用可能にする。

## `withRetry` の公開

WebDriverの既存ロジックにリトライ施行があったが、
`CommandTestHelper` の `withRetry` で同じ挙動を再現できるので、
これを `CartonHelpers` に移動して共通化する。

これはリトライ時のメッセージも出すので、
よりユーザが状況を把握しやすい。
以下は実例のテストの出力で、safaridriver + curlの場合に、
curlの呼び出しが早すぎて一回失敗していることがわかる

```
Test Suite 'Selected tests' started at 2024-05-26 15:24:29.299.
Test Suite 'WebDriverTests.xctest' started at 2024-05-26 15:24:29.299.
Test Suite 'WebDriverClientTests' started at 2024-05-26 15:24:29.299.
Test Case '-[WebDriverTests.WebDriverClientTests testGotoCurl]' started.
- checking WebDriver endpoint: [36m[1mWEBDRIVER_REMOTE_URL
[0m- checking WebDriver executable: [36m[1mWEBDRIVER_PATH
[0m- checking WebDriver executable in PATH: [36m[1mchromedriver, geckodriver, safaridriver, msedgedriver
[0mLaunch WebDriver executable: [36m[1m/usr/bin/safaridriver
[0mattempt 1 failed: /usr/bin/curl failed with status 7., retrying...
Test Case '-[WebDriverTests.WebDriverClientTests testGotoCurl]' passed (2.276 seconds).
Test Suite 'WebDriverClientTests' passed at 2024-05-26 15:24:31.576.
	 Executed 1 test, with 0 failures (0 unexpected) in 2.276 (2.277) seconds
Test Suite 'WebDriverTests.xctest' passed at 2024-05-26 15:24:31.576.
	 Executed 1 test, with 0 failures (0 unexpected) in 2.276 (2.278) seconds
Test Suite 'Selected tests' passed at 2024-05-26 15:24:31.577.
	 Executed 1 test, with 0 failures (0 unexpected) in 2.276 (2.278) seconds
Program ended with exit code: 0
```

## `WebDriver` モジュールへの名前変更

`WebDriverService` なども含まれたので、
`WebDriverClient` モジュールを `WebDriver` モジュールに名前変更する