### PR TITLE
Add --bind to specify serving address with relaxed default (0.0.0.0)

### DIFF
--- a/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
@@ -51,14 +51,25 @@ struct CartonFrontendDevCommand: AsyncParsableCommand {
   @Flag(name: .shortAndLong, help: "Don't clear terminal window after files change.")
   var verbose = false
 
+  @Option(
+    name: .shortAndLong,
+    help: """
+      Set the address where the development server will listen for connections.
+      """
+  )
+  var listen: String = "0.0.0.0"
+
   @Option(name: .shortAndLong, help: "Set the HTTP port the development server will run on.")
   var port = 8080
 
   @Option(
     name: .shortAndLong,
-    help: "Set the location where the development server will run. Default is `127.0.0.1`."
+    help: """
+      Set the location where the development server will run.
+      The default value is derived from the –-listen option.
+      """
   )
-  var host = "127.0.0.1"
+  var host: String?
 
   @Flag(name: .long, help: "Skip automatically opening app in system browser.")
   var skipAutoOpen = false
@@ -150,8 +161,9 @@ struct CartonFrontendDevCommand: AsyncParsableCommand {
         mainWasmPath: AbsolutePath(
           validating: mainWasmPath, relativeTo: localFileSystem.currentWorkingDirectory!),
         verbose: verbose,
+        listen: listen,
         port: port,
-        host: host,
+        host: Server.Configuration.host(listen: listen, host: host),
         customIndexPath: customIndexPage.map {
           try AbsolutePath(validating: $0, relativeTo: localFileSystem.currentWorkingDirectory!)
         },

--- a/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
@@ -52,7 +52,7 @@ struct CartonFrontendDevCommand: AsyncParsableCommand {
   var verbose = false
 
   @Option(
-    name: .shortAndLong,
+    name: .long,
     help: """
       Set the address where the development server will listen for connections.
       """

--- a/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
@@ -52,12 +52,12 @@ struct CartonFrontendDevCommand: AsyncParsableCommand {
   var verbose = false
 
   @Option(
-    name: .long,
+    name: .shortAndLong,
     help: """
       Set the address where the development server will listen for connections.
       """
   )
-  var listen: String = "0.0.0.0"
+  var bind: String = "0.0.0.0"
 
   @Option(name: .shortAndLong, help: "Set the HTTP port the development server will run on.")
   var port = 8080
@@ -66,7 +66,7 @@ struct CartonFrontendDevCommand: AsyncParsableCommand {
     name: .shortAndLong,
     help: """
       Set the location where the development server will run.
-      The default value is derived from the –-listen option.
+      The default value is derived from the –-bind option.
       """
   )
   var host: String?
@@ -161,9 +161,9 @@ struct CartonFrontendDevCommand: AsyncParsableCommand {
         mainWasmPath: AbsolutePath(
           validating: mainWasmPath, relativeTo: localFileSystem.currentWorkingDirectory!),
         verbose: verbose,
-        listen: listen,
+        bindingAddress: bind,
         port: port,
-        host: Server.Configuration.host(listen: listen, host: host),
+        host: Server.Configuration.host(bindOption: bind, hostOption: host),
         customIndexPath: customIndexPage.map {
           try AbsolutePath(validating: $0, relativeTo: localFileSystem.currentWorkingDirectory!)
         },

--- a/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
@@ -57,12 +57,12 @@ struct CartonFrontendTestCommand: AsyncParsableCommand {
   private var sanitize: SanitizeVariant?
 
   @Option(
-    name: .long,
+    name: .shortAndLong,
     help: """
       Set the address where the development server will listen for connections.
       """
   )
-  var listen: String = "0.0.0.0"
+  var bind: String = "0.0.0.0"
 
   @Option(
     name: .shortAndLong,
@@ -74,7 +74,7 @@ struct CartonFrontendTestCommand: AsyncParsableCommand {
     name: .shortAndLong,
     help: """
       Set the location where the development server will run.
-      The default value is derived from the –-listen option.
+      The default value is derived from the –-bind option.
       """
   )
   var host: String?
@@ -128,8 +128,8 @@ struct CartonFrontendTestCommand: AsyncParsableCommand {
     case .browser:
       try await BrowserTestRunner(
         testFilePath: bundlePath,
-        listen: listen,
-        host: Server.Configuration.host(listen: listen, host: host),
+        bindingAddress: bind,
+        host: Server.Configuration.host(bindOption: bind, hostOption: host),
         port: port,
         headless: headless,
         resourcesPaths: resources,

--- a/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
@@ -58,15 +58,26 @@ struct CartonFrontendTestCommand: AsyncParsableCommand {
 
   @Option(
     name: .shortAndLong,
+    help: """
+      Set the address where the development server will listen for connections.
+      """
+  )
+  var listen: String = "0.0.0.0"
+
+  @Option(
+    name: .shortAndLong,
     help: "Set the HTTP port the testing server will run on for browser environment."
   )
   var port = 8080
 
   @Option(
     name: .shortAndLong,
-    help: "Set the location where the testing server will run. Default is `127.0.0.1`."
+    help: """
+      Set the location where the development server will run.
+      The default value is derived from the –-listen option.
+      """
   )
-  var host = "127.0.0.1"
+  var host: String?
 
   @Option(help: "Use the given bundle instead of building the test target")
   var prebuiltTestBundlePath: String
@@ -117,7 +128,8 @@ struct CartonFrontendTestCommand: AsyncParsableCommand {
     case .browser:
       try await BrowserTestRunner(
         testFilePath: bundlePath,
-        host: host,
+        listen: listen,
+        host: Server.Configuration.host(listen: listen, host: host),
         port: port,
         headless: headless,
         resourcesPaths: resources,

--- a/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
@@ -57,7 +57,7 @@ struct CartonFrontendTestCommand: AsyncParsableCommand {
   private var sanitize: SanitizeVariant?
 
   @Option(
-    name: .shortAndLong,
+    name: .long,
     help: """
       Set the address where the development server will listen for connections.
       """

--- a/Sources/CartonFrontend/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonFrontend/Commands/TestRunners/BrowserTestRunner.swift
@@ -48,6 +48,7 @@ enum BrowserTestRunnerError: Error, CustomStringConvertible {
 
 struct BrowserTestRunner: TestRunner {
   let testFilePath: AbsolutePath
+  let listen: String
   let host: String
   let port: Int
   let headless: Bool
@@ -57,6 +58,7 @@ struct BrowserTestRunner: TestRunner {
 
   init(
     testFilePath: AbsolutePath,
+    listen: String,
     host: String,
     port: Int,
     headless: Bool,
@@ -64,6 +66,7 @@ struct BrowserTestRunner: TestRunner {
     terminal: InteractiveWriter
   ) {
     self.testFilePath = testFilePath
+    self.listen = listen
     self.host = host
     self.port = port
     self.headless = headless
@@ -77,6 +80,7 @@ struct BrowserTestRunner: TestRunner {
         builder: nil,
         mainWasmPath: testFilePath,
         verbose: true,
+        listen: listen,
         port: port,
         host: host,
         customIndexPath: nil,

--- a/Sources/CartonFrontend/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonFrontend/Commands/TestRunners/BrowserTestRunner.swift
@@ -48,7 +48,7 @@ enum BrowserTestRunnerError: Error, CustomStringConvertible {
 
 struct BrowserTestRunner: TestRunner {
   let testFilePath: AbsolutePath
-  let listen: String
+  let bindingAddress: String
   let host: String
   let port: Int
   let headless: Bool
@@ -58,7 +58,7 @@ struct BrowserTestRunner: TestRunner {
 
   init(
     testFilePath: AbsolutePath,
-    listen: String,
+    bindingAddress: String,
     host: String,
     port: Int,
     headless: Bool,
@@ -66,7 +66,7 @@ struct BrowserTestRunner: TestRunner {
     terminal: InteractiveWriter
   ) {
     self.testFilePath = testFilePath
-    self.listen = listen
+    self.bindingAddress = bindingAddress
     self.host = host
     self.port = port
     self.headless = headless
@@ -80,7 +80,7 @@ struct BrowserTestRunner: TestRunner {
         builder: nil,
         mainWasmPath: testFilePath,
         verbose: true,
-        listen: listen,
+        bindingAddress: bindingAddress,
         port: port,
         host: host,
         customIndexPath: nil,

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -135,7 +135,7 @@ public actor Server {
     let builder: BuilderProtocol?
     let mainWasmPath: AbsolutePath
     let verbose: Bool
-    let listen: String
+    let bindingAddress: String
     let port: Int
     let host: String
     let customIndexPath: AbsolutePath?
@@ -147,7 +147,7 @@ public actor Server {
       builder: BuilderProtocol?,
       mainWasmPath: AbsolutePath,
       verbose: Bool,
-      listen: String,
+      bindingAddress: String,
       port: Int,
       host: String,
       customIndexPath: AbsolutePath?,
@@ -158,7 +158,7 @@ public actor Server {
       self.builder = builder
       self.mainWasmPath = mainWasmPath
       self.verbose = verbose
-      self.listen = listen
+      self.bindingAddress = bindingAddress
       self.port = port
       self.host = host
       self.customIndexPath = customIndexPath
@@ -167,10 +167,10 @@ public actor Server {
       self.terminal = terminal
     }
 
-    public static func host(listen: String, host: String?) -> String {
-      if let host { return host }
-      if listen == "0.0.0.0" { return "127.0.0.1" }
-      return listen
+    public static func host(bindOption: String, hostOption: String?) -> String {
+      if let hostOption { return hostOption }
+      if bindOption == "0.0.0.0" { return "127.0.0.1" }
+      return bindOption
     }
   }
 
@@ -313,7 +313,7 @@ public actor Server {
       }
       // Enable SO_REUSEADDR for the accepted Channels
       .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-      .bind(host: configuration.listen, port: configuration.port)
+      .bind(host: configuration.bindingAddress, port: configuration.port)
       .get()
 
     self.serverChannel = channel

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -304,7 +304,7 @@ public actor Server {
       }
       // Enable SO_REUSEADDR for the accepted Channels
       .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-      .bind(host: configuration.host, port: configuration.port)
+      .bind(host: "0.0.0.0", port: configuration.port)
       .get()
 
     self.serverChannel = channel

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -135,6 +135,7 @@ public actor Server {
     let builder: BuilderProtocol?
     let mainWasmPath: AbsolutePath
     let verbose: Bool
+    let listen: String
     let port: Int
     let host: String
     let customIndexPath: AbsolutePath?
@@ -146,6 +147,7 @@ public actor Server {
       builder: BuilderProtocol?,
       mainWasmPath: AbsolutePath,
       verbose: Bool,
+      listen: String,
       port: Int,
       host: String,
       customIndexPath: AbsolutePath?,
@@ -156,12 +158,19 @@ public actor Server {
       self.builder = builder
       self.mainWasmPath = mainWasmPath
       self.verbose = verbose
+      self.listen = listen
       self.port = port
       self.host = host
       self.customIndexPath = customIndexPath
       self.resourcesPaths = resourcesPaths
       self.entrypoint = entrypoint
       self.terminal = terminal
+    }
+
+    public static func host(listen: String, host: String?) -> String {
+      if let host { return host }
+      if listen == "0.0.0.0" { return "127.0.0.1" }
+      return listen
     }
   }
 
@@ -304,7 +313,7 @@ public actor Server {
       }
       // Enable SO_REUSEADDR for the accepted Channels
       .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-      .bind(host: "0.0.0.0", port: configuration.port)
+      .bind(host: configuration.listen, port: configuration.port)
       .get()
 
     self.serverChannel = channel


### PR DESCRIPTION
# 現状

dev server は `--host` で指定したアドレスで待ち受けします。

# 課題

## 指定しない場合

仮に `--host` がデフォルトの 127.0.0.1 の場合、
同一ホスト上から `http://127.0.0.1:8080` へのアクセスでなければ接続できません。

ホストのLAN IPが 192.168.1.2 だったとして、 `http://192.168.1.2:8080` では接続できません。
また、同一LAN の他のマシンやスマートフォンからも接続できません。
ウェブアプリ開発ではスマホを対象にしたりするのでこれは不便です。

## 指定する場合

`--host` で 192.168.1.2 を指定すれば、それで接続できますが、
この場合は同一ホストであっても `127.0.0.1` から接続できません。

状況に応じて使い分ける必要があり、面倒です。

また、Docker内部で起動する場合、
コンテナのネットワークアドレスが必要ですが、
これを把握するのは多少面倒です。

# 提案

こういった状況のために、ソケットインターフェースには待ち受けアドレスとして `0.0.0.0` が指定できます。
これはそのホストのあらゆるアドレスからの接続を受け入れる特別な設定です。
これで起動すれば、接続元に応じたホストのアドレスを指定するだけで良いので簡単です。

知る限りでは、 `npx serve` コマンドや `nc` コマンド、 vitejs の devサーバ なども、
デフォルトではこのモードで待ち受けおり、一般的です。

そこで、新たに `--bind` オプションを導入し、待ち受けアドレスを指定できるようにしつつ、
そのデフォルト値として `0.0.0.0` を指定します。

`--host` オプションのデフォルト値は `127.0.0.1` を使うのをやめて、
`--bind` オプションの値を使うようにします。

ただし、 `0.0.0.0` は接続先アドレスとして不正です。
例えばSafariではこれはエラーとなり接続できません。

そこで、 `--bind` オプションが `0.0.0.0` の場合は、
`--host` オプションの値は `127.0.0.1` にします。
この書き換えは、Chromeのアドレスバーに `0.0.0.0` を指定した時と同じ挙動です。

## `--host` の用途

`--host` を指定する機能はこれまで通り必要です。
立ち上がったサーバに接続するためのURLを構築するために使われているからです。

## セキュリティ

待ち受けアドレスを限定するのはセキュリティを高める効果があります。
意図しない外部からの接続を遮断できるからです。
例えば postgresql などは初期状態でそのように設定されています。
この変更はそれを低下させます。

しかし、 dev server はデーモンとして常駐させるような使い方よりも、
明示的に CLI から起動し、フロントエンドジョブとしてユーザが運用するものなので、
影響は小さいです。