### PR TITLE
Refactor utilities under Foundation.Process and CartonHelpers.Process and share implementations

### DIFF
--- a/Plugins/CartonBundlePlugin/CartonBundlePluginCommand.swift
+++ b/Plugins/CartonBundlePlugin/CartonBundlePluginCommand.swift
@@ -85,12 +85,6 @@ struct CartonBundlePluginCommand: CommandPlugin {
         ["--resources", $0.string]
       } + extractor.remainingArguments
     let frontend = try makeCartonFrontendProcess(context: context, arguments: frontendArguments)
-    try frontend.checkRun(
-      printsLoadingMessage: false,
-      didExit: {
-        print("Bundle written in \(bundleDirectory)")
-      },
-      forwardExit: true
-    )
+    try frontend.checkRun(printsLoadingMessage: false, forwardExit: true)
   }
 }

--- a/Plugins/CartonBundlePlugin/CartonBundlePluginCommand.swift
+++ b/Plugins/CartonBundlePlugin/CartonBundlePluginCommand.swift
@@ -85,12 +85,12 @@ struct CartonBundlePluginCommand: CommandPlugin {
         ["--resources", $0.string]
       } + extractor.remainingArguments
     let frontend = try makeCartonFrontendProcess(context: context, arguments: frontendArguments)
-    frontend.forwardTerminationSignals()
-    try frontend.run()
-    frontend.waitUntilExit()
-    if frontend.terminationStatus == 0 {
-      print("Bundle written in \(bundleDirectory)")
-    }
-    frontend.checkNonZeroExit()
+    try frontend.checkRun(
+      printsLoadingMessage: false,
+      didExit: {
+        print("Bundle written in \(bundleDirectory)")
+      },
+      forwardExit: true
+    )
   }
 }

--- a/Plugins/CartonDevPlugin/CartonDevPluginCommand.swift
+++ b/Plugins/CartonDevPlugin/CartonDevPluginCommand.swift
@@ -114,7 +114,7 @@ struct CartonDevPluginCommand: CommandPlugin {
     }
 
     frontend.waitUntilExit()
-    frontend.checkNonZeroExit()
+    frontend.forwardExit()
   }
 
   private func defaultProduct(context: PluginContext) throws -> String {

--- a/Plugins/CartonTestPlugin/CartonTestPluginCommand.swift
+++ b/Plugins/CartonTestPlugin/CartonTestPluginCommand.swift
@@ -109,10 +109,7 @@ struct CartonTestPluginCommand: CommandPlugin {
         ["--resources", $0.string]
       } + extractor.remainingArguments
     let frontend = try makeCartonFrontendProcess(context: context, arguments: frontendArguments)
-    frontend.forwardTerminationSignals()
-    try frontend.run()
-    frontend.waitUntilExit()
-    frontend.checkNonZeroExit()
+    try frontend.checkRun(printsLoadingMessage: false, forwardExit: true)
   }
 
   private func buildDirectory(context: PluginContext) throws -> Path {

--- a/Sources/CartonCore/CartonCoreError.swift
+++ b/Sources/CartonCore/CartonCoreError.swift
@@ -1,0 +1,6 @@
+struct CartonCoreError: Error & CustomStringConvertible {
+  init(_ description: String) {
+    self.description = description
+  }
+  var description: String
+}

--- a/Sources/CartonCore/FoundationProcessEx.swift
+++ b/Sources/CartonCore/FoundationProcessEx.swift
@@ -14,7 +14,7 @@ extension Foundation.Process {
 
   public func forwardTerminationSignals() {
     setSignalForwarding(SIGINT)
-    setSignalForwarding(SIGKILL)
+    setSignalForwarding(SIGTERM)
   }
 
   public var commandLine: String {

--- a/Sources/CartonCore/FoundationProcessEx.swift
+++ b/Sources/CartonCore/FoundationProcessEx.swift
@@ -38,19 +38,15 @@ extension Foundation.Process {
 
   public func checkRun(
     printsLoadingMessage: Bool,
-    didExit: (() -> Void)? = nil,
     forwardExit: Bool = false
   ) throws {
     if printsLoadingMessage {
-      fputs("Running \(try commandLine)\n", stderr)
-      fflush(stderr)
+      print("Running \(try commandLine)")
     }
 
     try run()
     forwardTerminationSignals()
     waitUntilExit()
-
-    didExit?()
 
     if forwardExit {
       self.forwardExit()
@@ -76,7 +72,6 @@ extension Foundation.Process {
     _ executableURL: URL,
     arguments: [String],
     printsLoadingMessage: Bool = true,
-    didExit: (() -> Void)? = nil,
     forwardExit: Bool = false
   ) throws {
     let process = Foundation.Process()
@@ -84,7 +79,6 @@ extension Foundation.Process {
     process.arguments = arguments
     try process.checkRun(
       printsLoadingMessage: printsLoadingMessage,
-      didExit: didExit,
       forwardExit: forwardExit
     )
   }

--- a/Sources/CartonCore/FoundationProcessEx.swift
+++ b/Sources/CartonCore/FoundationProcessEx.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+extension Foundation.Process {
+  // Monitor termination/interrruption signals to forward them to child process
+  public func setSignalForwarding(_ signalNo: Int32) {
+    signal(signalNo, SIG_IGN)
+    let signalSource = DispatchSource.makeSignalSource(signal: signalNo)
+    signalSource.setEventHandler { [self] in
+      signalSource.cancel()
+      kill(processIdentifier, signalNo)
+    }
+    signalSource.resume()
+  }
+
+  public func forwardTerminationSignals() {
+    setSignalForwarding(SIGINT)
+    setSignalForwarding(SIGKILL)
+  }
+
+  public var commandLine: String {
+    get throws {
+      guard let executableURL else {
+        throw CartonCoreError("executableURL is none")
+      }
+
+      let commandLineArgs: [String] = [
+        executableURL.path
+      ] + (arguments ?? [])
+
+      let q = "\""
+      let commandLine: String = commandLineArgs
+        .map { "\(q)\($0)\(q)" }
+        .joined(separator: " ")
+
+      return commandLine
+    }
+  }
+
+  public func checkRun(
+    printsLoadingMessage: Bool,
+    didExit: (() -> Void)? = nil,
+    forwardExit: Bool = false
+  ) throws {
+    if printsLoadingMessage {
+      fputs("Running \(try commandLine)\n", stderr)
+      fflush(stderr)
+    }
+
+    try run()
+    forwardTerminationSignals()
+    waitUntilExit()
+
+    didExit?()
+
+    if forwardExit {
+      self.forwardExit()
+    }
+
+    try checkNonZeroExit()
+  }
+
+  public func forwardExit() {
+    exit(terminationStatus)
+  }
+
+  public func checkNonZeroExit() throws {
+    if terminationStatus != 0 {
+      throw CartonCoreError(
+        "Process failed with status \(terminationStatus).\n" +
+        "Command line: \(try commandLine)"
+      )
+    }
+  }
+
+  public static func checkRun(
+    _ executableURL: URL,
+    arguments: [String],
+    printsLoadingMessage: Bool = true,
+    didExit: (() -> Void)? = nil,
+    forwardExit: Bool = false
+  ) throws {
+    let process = Foundation.Process()
+    process.executableURL = executableURL
+    process.arguments = arguments
+    try process.checkRun(
+      printsLoadingMessage: printsLoadingMessage,
+      didExit: didExit,
+      forwardExit: forwardExit
+    )
+  }
+}

--- a/Sources/CartonFrontend/Commands/CartonFrontendBundleCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendBundleCommand.swift
@@ -129,7 +129,7 @@ struct CartonFrontendBundleCommand: AsyncParsableCommand {
       topLevelResourcePaths: resources
     )
 
-    terminal.write("Bundle generation finished successfully\n", inColor: .green, bold: true)
+    terminal.write("Bundle successfully generated at \(bundleDirectory)\n", inColor: .green, bold: true)
   }
 
   func optimize(_ inputPath: AbsolutePath, outputPath: AbsolutePath, terminal: InteractiveWriter)

--- a/Sources/CartonHelpers/ProcessEx.swift
+++ b/Sources/CartonHelpers/ProcessEx.swift
@@ -10,6 +10,14 @@ extension ProcessResult {
       stderrOutput: stderrOutput
     )
   }
+
+  @discardableResult
+  public func checkNonZeroExit() throws -> String {
+    guard exitStatus == .terminated(code: 0) else {
+        throw ProcessResult.Error.nonZeroExit(self)
+    }
+    return try utf8Output()
+  }
 }
 
 @discardableResult

--- a/Sources/CartonHelpers/ProcessEx.swift
+++ b/Sources/CartonHelpers/ProcessEx.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Dispatch
 
 extension ProcessResult {

--- a/Sources/CartonHelpers/ProcessEx.swift
+++ b/Sources/CartonHelpers/ProcessEx.swift
@@ -1,3 +1,5 @@
+import Dispatch
+
 extension ProcessResult {
   public mutating func setOutput(_ value: Result<[UInt8], any Swift.Error>) {
     self = ProcessResult(
@@ -8,12 +10,29 @@ extension ProcessResult {
       stderrOutput: stderrOutput
     )
   }
+}
 
-  @discardableResult
-  public func checkNonZeroExit() throws -> String {
-    guard exitStatus == .terminated(code: 0) else {
-        throw ProcessResult.Error.nonZeroExit(self)
+@discardableResult
+private func osSignal(
+  _ sig: Int32,
+  _ fn: (@convention(c) (Int32) -> Void)?
+) -> (@convention(c) (Int32) -> Void)? {
+  signal(sig, fn)
+}
+
+extension Process {
+  public func setSignalForwarding(_ signalNo: Int32) {
+    osSignal(signalNo, SIG_IGN)
+    let signalSource = DispatchSource.makeSignalSource(signal: signalNo)
+    signalSource.setEventHandler {
+      signalSource.cancel()
+      self.signal(signalNo)
     }
-    return try utf8Output()
+    signalSource.resume()
+  }
+
+  public func forwardTerminationSignals() {
+    setSignalForwarding(SIGINT)
+    setSignalForwarding(SIGTERM)
   }
 }

--- a/Tests/CartonCommandTests/CommandTestHelper.swift
+++ b/Tests/CartonCommandTests/CommandTestHelper.swift
@@ -100,17 +100,7 @@ func swiftRunProcess(
 
   try process.launch()
 
-  func setSignalForwarding(_ signalNo: Int32) {
-    signal(signalNo, SIG_IGN)
-    let signalSource = DispatchSource.makeSignalSource(signal: signalNo)
-    signalSource.setEventHandler {
-      signalSource.cancel()
-      process.signal(SIGINT)
-    }
-    signalSource.resume()
-  }
-  setSignalForwarding(SIGINT)
-  setSignalForwarding(SIGTERM)
+  process.forwardTerminationSignals()
 
   return SwiftRunProcess(
     process: process,

--- a/Tests/CartonCommandTests/CommandTestHelper.swift
+++ b/Tests/CartonCommandTests/CommandTestHelper.swift
@@ -127,7 +127,7 @@ func fetchWebContent(at url: URL, timeout: Duration) async throws -> (response: 
   )
 
   let (body, response) = try await session.data(for: request)
-  
+
   guard let response = response as? HTTPURLResponse else {
     throw CommandTestError("Response from \(url.absoluteString) is not HTTPURLResponse")
   }

--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -43,24 +43,23 @@ final class DevCommandTests: XCTestCase {
       // FIXME: Don't assume a specific port is available since it can be used by others or tests
       try await withFixture("EchoExecutable") { packageDirectory in
         let process = try swiftRunProcess(
-          ["carton", "dev", "--verbose", "--port", "8081", "--skip-auto-open"],
+          ["carton", "dev", "--verbose", "--port", "8080", "--skip-auto-open"],
           packageDirectory: packageDirectory.asURL
         )
 
-        try await checkForExpectedContent(process: process, at: "http://127.0.0.1:8081")
+        try await checkForExpectedContent(process: process, at: "http://127.0.0.1:8080")
       }
     }
   #endif
 
   private func fetchDevServerWithRetry(at url: URL) async throws -> (response: HTTPURLResponse, body: Data) {
     // client time out for connecting and responding
-    let timeOut: Duration = .seconds(60)
+    let timeOut: Duration = .seconds(10)
 
     // client delay... let the server start up
-    let delay: Duration = .seconds(30)
+    let delay: Duration = .seconds(3)
 
-    // only try 5 times.
-    let count = 5
+    let count = 100
 
     do {
       return try await withRetry(maxAttempts: count, initialDelay: delay, retryInterval: delay) {
@@ -78,7 +77,7 @@ final class DevCommandTests: XCTestCase {
   func checkForExpectedContent(process: SwiftRunProcess, at url: String) async throws {
     defer {
       // end the process regardless of success
-      process.process.signal(SIGTERM)
+      process.process.signal(SIGINT)
     }
 
     let (response, data) = try await fetchDevServerWithRetry(at: try URL(string: url).unwrap("url"))


### PR DESCRIPTION
# 背景・課題

driver, plugin, test では Foundation.Process が使われています。
frontend, test では CartonHelpers(TSC).Process が使われています。

そして、driver と plugin と frontend の3箇所で、
それぞれ Process の拡張が行われています。

そのためプロジェクトを横断的に読み書きするのが難しくなっています。

同じことをやりたくても書き方が違ったり、
同じメソッド名なのに挙動が違ったりもするからです。
また、同じものが重複して実装されている部分もあります。

# 提案

このパッチではそういったユーティリティを整理して統一・共通化します。

## `TSC.Process` の拡張については `CartonHelpers` モジュールに移動します。

`TSC.Process` と一緒に定義すれば良いからです。

## `Foundation.Process` の拡張については、 `CartonCore` モジュールに移動します。

`CartonCore` はdriver, plugin の両方からアクセスできるモジュールとして最近定義されました。

## `setSignalForwarding` の統一

これは TSC と Foundation の両方で局所的に書かれているので、
どちらもメソッドとして定義します。
ついでにバグがあったので直します。

## `forwardTerminationSignals` の統一

`setSignalForwarding` を `SIGINT` と `SIGTERM` について設定する操作はよく出てくるので、
このメソッド名で統一します。

なお、元々はこれに `terminationHandler` による `exit` の転送が書いてありましたが、
これは削除しました。

`waitUntilExit` と一緒に使っていて意味がなかったからです。
`waitUntilExit` は `terminationHandler` の完了を待たないので、
そもそもレースコンディションが起きていました。
`waitUntilExit` の後で exit forward すれば十分で、その方が安定します。

## `checkRun` の整理

`Foudation.Process` には static func な `checkRun` があります。
一方で、通常の `run` をさまざまな準備とともに使っている場所もあります。

この、さまざまな準備の処理は、ほとんど `checkRun` と被っています。

そこで、instance func な `checkRun` を実装してから、
static func な `checkRun` はそれを呼び出す形に書き換えます。

また、 `checkRun` の内部で使われているいくつかの処理は定型なので、
これもメソッドとして切り出します。

具体的には、 `forwardExit` と `checkNonZeroExit` を切り出しました。

## シグナル転送の改修

従来、シグナル転送のロジックでは、
SIGINTとSIGTERMを受け取って、サブプロセスに SIGINT を送る実装になっていました。

ユーザはターミナルからSIGTERMを送ったはずなのに、
プロセスはSIGINTを受け取るということが起きてしまうのでこれは良くないと思います。

SIGINT を受け取ったら SIGINT を転送し、
SIGTERM を受け取ったら SIGTERM を転送するのが良いと思います。

ただし、 `$ swift package plugin` コマンドは、
SIGINT の転送をするが SIGTERM は転送しないようでした。
これは別途、swiftpmの実装を確認する予定です。

テストコードの中に carton driver に対して SIGTERM を送信するロジックがあり、
これが先述の転送挙動と組み合わさっていたために、
これを修正したところうまく終了できませんでした。

そのため、テストコードは SIGINT を送信するように修正しました。