### PR TITLE
Add `-Xwasm-opt` option to `bundle` subcommand

### DIFF
--- a/Sources/CartonFrontend/Commands/CartonFrontendBundleCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendBundleCommand.swift
@@ -60,6 +60,12 @@ struct CartonFrontendBundleCommand: AsyncParsableCommand {
   )
   var wasmOptimizations: WasmOptimizations = .size
 
+  @Option(
+    name: .customLong("Xwasm-opt", withSingleDash: true),
+    help: "Extra flags to pass to wasm-opt when optimizing the .wasm binary."
+  )
+  var extraWasmOptFlags: [String] = []
+
   @Flag(inversion: .prefixedNo, help: "Use a content hash for the output file names.")
   var contentHash: Bool = true
 
@@ -141,6 +147,7 @@ struct CartonFrontendBundleCommand: AsyncParsableCommand {
     if debugInfo {
       wasmOptArgs.append("--debuginfo")
     }
+    wasmOptArgs.append(contentsOf: extraWasmOptFlags)
     try await Process.run(wasmOptArgs, terminal)
     try terminal.logLookup(
       "After stripping debug info the main binary size is ",

--- a/Tests/CartonCommandTests/BundleCommandTests.swift
+++ b/Tests/CartonCommandTests/BundleCommandTests.swift
@@ -126,4 +126,19 @@ final class BundleCommandTests: XCTestCase {
       XCTAssertGreaterThan(none, optimized)
     }
   }
+
+  func testExtraOptions() async throws {
+    try await withFixture("EchoExecutable") { packageDirectory in
+      let result = try await swiftRun(
+        ["carton", "bundle", "-Xwasm-opt=--enable-threads"],
+        packageDirectory: packageDirectory.asURL
+      )
+      try result.checkNonZeroExit()
+      let output = try result.utf8Output()
+      let hasExpectedLine = output.split(whereSeparator: \.isNewline).contains {
+          $0.contains(#/wasm-opt (.+ )?--enable-threads/#)
+      }
+      XCTAssert(hasExpectedLine, "wasm-opt invocation log with extra options not found in output: \(output)")
+    }
+  }
 }


### PR DESCRIPTION
The `-Xwasm-opt` option allows users to pass extra flags to `wasm-opt` optimizer. This is especially useful for enabling some future features like `--enable-threads`.