### PR TITLE
Verify if tests communicate with just spawned dev server

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -116,7 +116,10 @@ let package = Package(
         "WebDriver",
         "WasmTransformer",
       ],
-      exclude: ["Utilities/README.md"]
+      exclude: ["Utilities/README.md"],
+      swiftSettings: [
+        .enableUpcomingFeature("BareSlashRegexLiterals")
+      ]
     ),
     .target(
       name: "SwiftToolchain",

--- a/Sources/CartonCore/CartonCoreError.swift
+++ b/Sources/CartonCore/CartonCoreError.swift
@@ -1,6 +1,6 @@
-struct CartonCoreError: Error & CustomStringConvertible {
-  init(_ description: String) {
+public struct CartonCoreError: Error & CustomStringConvertible {
+  public init(_ description: String) {
     self.description = description
   }
-  var description: String
+  public  var description: String
 }

--- a/Sources/CartonDriver/CartonDriverCommand.swift
+++ b/Sources/CartonDriver/CartonDriverCommand.swift
@@ -54,6 +54,8 @@ func derivePackageCommandArguments(
   let pluginArguments: [String] = ["plugin"]
   var cartonPluginArguments: [String] = extraArguments
 
+  let pid = ProcessInfo.processInfo.processIdentifier
+
   switch subcommand {
   case "bundle":
     packageArguments += ["--disable-sandbox"]
@@ -64,6 +66,7 @@ func derivePackageCommandArguments(
     cartonPluginArguments = ["--output", "Bundle"] + cartonPluginArguments
   case "dev":
     packageArguments += ["--disable-sandbox"]
+    cartonPluginArguments += ["--pid", pid.description]
   case "test":
     // 1. Ask the plugin process to generate the build command based on the given options
     let commandFile = try makeTemporaryFile(prefix: "test-build")
@@ -92,6 +95,7 @@ func derivePackageCommandArguments(
 
     // "--environment browser" launches a http server
     packageArguments += ["--disable-sandbox"]
+    cartonPluginArguments += ["--pid", pid.description]
   default: break
   }
 

--- a/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
@@ -113,6 +113,8 @@ struct CartonFrontendDevCommand: AsyncParsableCommand {
   )
   var mainWasmPath: String
 
+  @Option(name: .long) var pid: Int32?
+
   static let configuration = CommandConfiguration(
     commandName: "dev",
     abstract: "Watch the current directory, host the app, rebuild on change."
@@ -169,6 +171,7 @@ struct CartonFrontendDevCommand: AsyncParsableCommand {
         },
         resourcesPaths: resources,
         entrypoint: Self.entrypoint,
+        pid: pid,
         terminal: terminal
       )
     )

--- a/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendDevCommand.swift
@@ -113,7 +113,7 @@ struct CartonFrontendDevCommand: AsyncParsableCommand {
   )
   var mainWasmPath: String
 
-  @Option(name: .long) var pid: Int32?
+  @Option(name: .long, help: .hidden) var pid: Int32?
 
   static let configuration = CommandConfiguration(
     commandName: "dev",

--- a/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
@@ -96,6 +96,8 @@ struct CartonFrontendTestCommand: AsyncParsableCommand {
   ))
   var pluginWorkDirectory: String = "./"
 
+  @Option(name: .long) var pid: Int32?
+
   func validate() throws {
     if headless && environment != .browser {
       throw TestError(
@@ -133,6 +135,7 @@ struct CartonFrontendTestCommand: AsyncParsableCommand {
         port: port,
         headless: headless,
         resourcesPaths: resources,
+        pid: pid,
         terminal: terminal
       ).run()
     case .node:

--- a/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendTestCommand.swift
@@ -96,7 +96,7 @@ struct CartonFrontendTestCommand: AsyncParsableCommand {
   ))
   var pluginWorkDirectory: String = "./"
 
-  @Option(name: .long) var pid: Int32?
+  @Option(name: .long, help: .hidden) var pid: Int32?
 
   func validate() throws {
     if headless && environment != .browser {

--- a/Sources/CartonFrontend/Commands/TestRunners/BrowserTestRunner.swift
+++ b/Sources/CartonFrontend/Commands/TestRunners/BrowserTestRunner.swift
@@ -53,6 +53,7 @@ struct BrowserTestRunner: TestRunner {
   let port: Int
   let headless: Bool
   let resourcesPaths: [String]
+  let pid: Int32?
   let terminal: InteractiveWriter
   let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
@@ -63,6 +64,7 @@ struct BrowserTestRunner: TestRunner {
     port: Int,
     headless: Bool,
     resourcesPaths: [String],
+    pid: Int32?,
     terminal: InteractiveWriter
   ) {
     self.testFilePath = testFilePath
@@ -71,6 +73,7 @@ struct BrowserTestRunner: TestRunner {
     self.port = port
     self.headless = headless
     self.resourcesPaths = resourcesPaths
+    self.pid = pid
     self.terminal = terminal
   }
 
@@ -86,6 +89,7 @@ struct BrowserTestRunner: TestRunner {
         customIndexPath: nil,
         resourcesPaths: resourcesPaths,
         entrypoint: Constants.entrypoint,
+        pid: pid,
         terminal: terminal
       )
     )

--- a/Sources/CartonKit/Server/ServerHTTPHandler.swift
+++ b/Sources/CartonKit/Server/ServerHTTPHandler.swift
@@ -28,6 +28,7 @@ final class ServerHTTPHandler: ChannelInboundHandler, RemovableChannelHandler {
     let customIndexPath: AbsolutePath?
     let resourcesPaths: [String]
     let entrypoint: Entrypoint
+    let serverName: String
   }
 
   let configuration: Configuration
@@ -93,6 +94,7 @@ final class ServerHTTPHandler: ChannelInboundHandler, RemovableChannelHandler {
     self.responseBody = response.body
 
     var headers = HTTPHeaders()
+    headers.add(name: "Server", value: configuration.serverName)
     headers.add(name: "Content-Type", value: response.contentType)
     headers.add(name: "Content-Length", value: String(response.body.readableBytes))
     headers.add(name: "Connection", value: "close")

--- a/Tests/CartonCommandTests/DevCommandTests.swift
+++ b/Tests/CartonCommandTests/DevCommandTests.swift
@@ -82,6 +82,7 @@ final class DevCommandTests: XCTestCase {
 
     let (response, data) = try await fetchDevServerWithRetry(at: try URL(string: url).unwrap("url"))
     XCTAssertEqual(response.statusCode, 200, "Response was not ok")
+    try checkServerNameField(response: response, expectedPID: process.process.processID)
 
     let expectedHtml = """
       <!DOCTYPE html>

--- a/Tests/CartonCommandTests/FrontendDevServerTests.swift
+++ b/Tests/CartonCommandTests/FrontendDevServerTests.swift
@@ -5,6 +5,70 @@ import CartonKit
 import SwiftToolchain
 import WebDriver
 
+struct DevServerClient {
+  var process: CartonHelpers.Process
+
+  init(
+    wasmFile: AbsolutePath,
+    resourcesDir: AbsolutePath,
+    terminal: InteractiveWriter,
+    onStdout: ((String) -> Void)?
+  ) throws {
+    process = Process(
+      arguments: [
+        "swift", "run", "carton-frontend", "dev",
+        "--skip-auto-open", "--verbose",
+        "--main-wasm-path", wasmFile.pathString,
+        "--resources", resourcesDir.pathString
+      ],
+      outputRedirection: .stream(
+        stdout: { (chunk) in
+          let string = String(decoding: chunk, as: UTF8.self)
+
+          onStdout?(string)
+
+          terminal.write(string)
+        }, stderr: { (_) in },
+        redirectStderr: true
+      )
+    )
+    try process.launch()
+  }
+
+  func dispose() {
+    process.signal(SIGINT)
+  }
+
+  func fetchBinary(
+    at url: URL,
+    file: StaticString = #file, line: UInt = #line
+  ) async throws -> Data {
+    let (response, body) = try await withRetry(
+      maxAttempts: 5, initialDelay: .seconds(3), retryInterval: .seconds(10)
+    ) {
+      try await fetchWebContent(at: url, timeout: .seconds(10))
+    }
+    XCTAssertEqual(response.statusCode, 200, file: file, line: line)
+
+    try checkServerNameField(response: response, expectedPID: process.processID)
+
+    return body
+  }
+
+  func fetchString(
+    at url: URL,
+    file: StaticString = #file, line: UInt = #line
+  ) async throws -> String {
+    let data = try await fetchBinary(at: url)
+
+    guard let string = String(data: data, encoding: .utf8) else {
+      throw CommandTestError("not UTF-8 string content")
+    }
+
+    return string
+  }
+}
+
 final class FrontendDevServerTests: XCTestCase {
   func testDevServerPublish() async throws {
     let fs = localFileSystem
@@ -33,42 +97,27 @@ final class FrontendDevServerTests: XCTestCase {
     var gotHelloStdout = false
     var gotHelloStderr = false
 
-    let devServer = Process(
-      arguments: [
-        "swift", "run", "carton-frontend", "dev",
-        "--skip-auto-open", "--verbose",
-        "--main-wasm-path", wasmFile.pathString,
-        "--resources", resourcesDir.pathString
-      ],
-      outputRedirection: .stream(
-        stdout: { (chunk) in
-          let string = String(decoding: chunk, as: UTF8.self)
-
-          if string.contains("stdout: hello stdout") {
-            gotHelloStdout = true
-          }
-          if string.contains("stderr: hello stderr") {
-            gotHelloStderr = true
-          }
-
-          terminal.write(string)
-        }, stderr: { (_) in },
-        redirectStderr: true
-      )
+    let cl = try DevServerClient(
+      wasmFile: wasmFile,
+      resourcesDir: resourcesDir,
+      terminal: terminal,
+      onStdout: { (string) in
+        if string.contains("stdout: hello stdout") {
+          gotHelloStdout = true
+        }
+        if string.contains("stderr: hello stderr") {
+          gotHelloStderr = true
+        }
+      }
     )
-    try devServer.launch()
     defer {
-      devServer.signal(SIGINT)
+      cl.dispose()
     }
 
     let host = try URL(string: "http://127.0.0.1:8080").unwrap("url")
 
     do {
-      let indexHtml = try await withRetry(
-        maxAttempts: 5, initialDelay: .seconds(3), retryInterval: .seconds(10)
-      ) {
-        try await fetchString(at: host)
-      }
+      let indexHtml = try await cl.fetchString(at: host)
 
       XCTAssertEqual(indexHtml, """
         <!DOCTYPE html>
@@ -86,32 +135,32 @@ final class FrontendDevServerTests: XCTestCase {
     }
 
     do {
-      let devJs = try await fetchString(at: host.appendingPathComponent("dev.js"))
+      let devJs = try await cl.fetchString(at: host.appendingPathComponent("dev.js"))
       let expected = try XCTUnwrap(String(data: StaticResource.dev, encoding: .utf8))
       XCTAssertEqual(devJs, expected)
     }
 
     do {
-      let mainWasm = try await fetchBinary(at: host.appendingPathComponent("main.wasm"))
+      let mainWasm = try await cl.fetchBinary(at: host.appendingPathComponent("main.wasm"))
       let expected = try Data(contentsOf: wasmFile.asURL)
       XCTAssertEqual(mainWasm, expected)
     }
 
     do {
       let name = "style.css"
-      let styleCss = try await fetchString(at: host.appendingPathComponent(name))
+      let styleCss = try await cl.fetchString(at: host.appendingPathComponent(name))
       let expected = try String(contentsOf: resourcesDir.appending(component: name).asURL)
       XCTAssertEqual(styleCss, expected)
     }
 
-    let service = try await WebDriverServices.find(terminal: terminal)
+    let webDriver = try await WebDriverServices.find(terminal: terminal)
     defer {
-      service.dispose()
+      webDriver.dispose()
     }
 
-    let client = try await service.client()
+    let webDriverClient = try await webDriver.client()
 
-    try await client.goto(url: host)
+    try await webDriverClient.goto(url: host)
 
     try await withRetry(maxAttempts: 10, initialDelay: .seconds(3), retryInterval: .seconds(3)) {
       if gotHelloStdout, gotHelloStderr {
@@ -120,29 +169,6 @@ final class FrontendDevServerTests: XCTestCase {
       throw CommandTestError("no output")
     }
 
-    try await client.closeSession()
-  }
-
-  private func fetchBinary(
-    at url: URL,
-    file: StaticString = #file, line: UInt = #line
-  ) async throws -> Data {
-    let (response, body) = try await fetchWebContent(at: url, timeout: .seconds(10))
-    XCTAssertEqual(response.statusCode, 200, file: file, line: line)
-    return body
-  }
-
-  private func fetchString(
-    at url: URL,
-    file: StaticString = #file, line: UInt = #line
-  ) async throws -> String? {
-    let data = try await fetchBinary(at: url)
-
-    guard let string = String(data: data, encoding: .utf8) else {
-      XCTFail("not UTF-8 string content", file: file, line: line)
-      return nil
-    }
-
-    return string
+    try await webDriverClient.closeSession()
   }
 }

--- a/Tests/Fixtures/EchoExecutable/Package.swift
+++ b/Tests/Fixtures/EchoExecutable/Package.swift
@@ -5,5 +5,5 @@ let package = Package(
   name: "Foo",
   products: [.executable(name: "my-echo", targets: ["my-echo"])],
   dependencies: [.package(path: "../../..")],
-  targets: [.target(name: "my-echo")]
+  targets: [.executableTarget(name: "my-echo")]
 )


### PR DESCRIPTION
# 背景・課題

DevCommandTests と FrontendDevServerTests では、テストケースの中で dev server を起動して、
それと通信して挙動を検証しています。

しかし、テスト実行中に別のターミナルで dev server が起動していたり、
全く別のプロセスがポートを使用していたり、
開発中のバグの影響で、以前起動したテスト用のプロセスがゾンビ化して生き残っていたりすると、
テストしようとした dev server が待ち受けポートを利用できずに起動に失敗してしまいます。

これは実際に、`SIGTERM` を `SIGINT` に意図せず変換してしまうバグを修正した時に、
`SIGTERM` のハンドルがされずにゾンビプロセスが生まれることによって、
CIがわかりづらい壊れ方をするなどの現象を引き起こしました。

起動に失敗したことによりテストが停止すれば良いのですが、
この起動の失敗を検出するのは困難です。
`carton dev` コマンドは swift ツールチェーンのインストールなども行うため、
プロセスが正常に実行されているのか、
将来的にサーバの起動に失敗する状況にあるかわからないからです。

起動時間が読めないこともあって、テストケースはHTTPリクエストをしばらくリトライします。
そして、別の理由で先に存在していた dev server がいた場合は、
テストプロセスのHTTP通信が成功してしまうため、
テストが誤って成功したり、予期し得ないレスポンスが返って意味不明な失敗をしたりします。

また、ゾンビプロセスが残っていることがわかった時、
それを特定して kill するまでの手順も多少面倒です。
macOS は `$ lsof -i -P` の実行に何故か結構待ち時間があります。

# 提案

テストを安定させるために、
HTTPレスポンスを返してきたサーバが期待したプロセスかどうか検証できるようにします。

そのため、HTTPレスポンスヘッダーの `Server:` フィールドを利用して、

```
Server: carton dev server/1.0.4 (PID 12345)
```

のような情報を返すようにします。

テストケースではこれを検証することによって、
そもそもそのテストケースのために起動したサーバプロセスと通信しているのかを検証し、
そうでなければエラーを出して停止するようにします。

また、これは開発中にゾンビプロセスが生じた場合にも便利です。
`$ curl -i localhost:8080` でヘッダを見れば pid がわかるからです。

## pid の指定

frontend を起動した場合はそれが直接サーバプロセスになりますが、
driver を起動した場合は、
carton driver → swiftpm plugin runner → carton plugin → carton frontend
と4階層のプロセスツリーができます。

この時、テストケースが知っているのは自分が起動した手元のdriverのpidなので、
サーバはその driver の pid を通知して欲しいです。

そこで、carton plugin と carton frontend に `--pid` オプションを追加して、
dev server が広告する carton のプロセス番号を指定できるようにします。

## 結果

以下のようにテストがうまく停止するようになりました。

<details>
<summary>FrontendDevServerTestsで検出成功した例</summary>

```
[omochi@omochi-mbp carton (server-name *)]$ swift test --filter FrontendDevServerTests
Building for debugging...
[5/5] Write swift-version-3874884F1997D323.txt
Build complete! (0.13s)
Test Suite 'Selected tests' started at 2024-06-05 22:12:14.472.
Test Suite 'cartonPackageTests.xctest' started at 2024-06-05 22:12:14.473.
Test Suite 'FrontendDevServerTests' started at 2024-06-05 22:12:14.473.
Test Case '-[CartonCommandTests.FrontendDevServerTests testDevServerPublish]' started.
Running...
swift build --target carton-frontend
Building for debugging...
[0/1] Write swift-version-3874884F1997D323.txt
Build complete! (0.18s)
`swift` process finished successfully
warning: 'devservertestapp': 'app' was identified as an executable target given the presence of a 'main.swift' file. Starting with tools version 5.4.0 executable targets should be declared as 'executableTarget()'
Building for debugging...
[0/3] Write swift-version-3874884F1997D323.txt
Build complete! (0.11s)
Error: bind(descriptor:p
tr:bytes:): Address already in use (errn
o: 48)
/Users/omochi/github/swiftwasm/carton/Tests/CartonCommandTests/CommandTestHelper.swift:152: error: -[CartonCommandTests.FrontendDevServerTests testDevServerPublish] : failed: caught error: "Expected PID 51718 but got PID 51474."
Test Case '-[CartonCommandTests.FrontendDevServerTests testDevServerPublish]' failed (3.562 seconds).
Test Suite 'FrontendDevServerTests' failed at 2024-06-05 22:12:18.035.
	 Executed 1 test, with 1 failure (1 unexpected) in 3.562 (3.562) seconds
Test Suite 'cartonPackageTests.xctest' failed at 2024-06-05 22:12:18.035.
	 Executed 1 test, with 1 failure (1 unexpected) in 3.562 (3.562) seconds
Test Suite 'Selected tests' failed at 2024-06-05 22:12:18.035.
	 Executed 1 test, with 1 failure (1 unexpected) in 3.562 (3.563) seconds
```
</details>

<details><summary>DevCommandTestsで検出成功した例</summary>

```
[omochi@omochi-mbp carton (server-name =)]$ swift test --filter DevCommandTests.testWithArguments
Building for debugging...
[5/5] Write swift-version-3874884F1997D323.txt
Build complete! (0.13s)
Test Suite 'Selected tests' started at 2024-06-05 22:14:29.061.
Test Suite 'cartonPackageTests.xctest' started at 2024-06-05 22:14:29.062.
Test Suite 'DevCommandTests' started at 2024-06-05 22:14:29.062.
Test Case '-[CartonCommandTests.DevCommandTests testWithArguments]' started.
Building for debugging...
[0/3] Write swift-version-3874884F1997D323.txt
Build complete! (0.11s)
- checking Swift compiler path: /Users/omochi/.carton/sdk/wasm-5.9.2-RELEASE/usr/bin/swift
- checking Swift compiler path: /Users/omochi/.swiftenv/versions/wasm-5.9.2-RELEASE/usr/bin/swift
- checking Swift compiler path: /Users/omochi/Library/Developer/Toolchains/swift-wasm-5.9.2-RELEASE.xctoolchain/usr/bin/swift
Inferring basic settings...
- swift executable:
/Users/omochi/Library/Developer/Toolchains/swift-wasm-5.9.2-RELEASE.xctoolchain/usr/bin/swift
SwiftWasm Swift version 5.9.2 (swift-5.9.2-RELEASE)
Target: x86_64-apple-darwin23.5.0
Building for debugging...
Build complete! (0.71s)
error: Plugin ended with exit code 1
Building "my-echo"

Watching these directories for changes:
/Users/omochi/github/swiftwasm/carton/Tests/Fixtures/EchoExecutable/Sources/my-echo

Error: bind(descriptor:ptr:bytes:): Address already in use (errno: 48)
Running "/Users/omochi/Library/Developer/Toolchains/swift-wasm-5.9.2-RELEASE.xctoolchain/usr/bin/swift" "package" "--triple" "wasm32-unknown-wasi" "--scratch-path" "/Users/omochi/github/swiftwasm/carton/Tests/Fixtures/EchoExecutable/.build/carton" "--disable-sandbox" "plugin" "carton-dev" "--verbose" "--port" "8080" "--skip-auto-open" "--pid" "53193"
/Users/omochi/github/swiftwasm/carton/Tests/CartonCommandTests/CommandTestHelper.swift:152: error: -[CartonCommandTests.DevCommandTests testWithArguments] : failed: caught error: "Expected PID 53193 but got PID 51474."
Test Case '-[CartonCommandTests.DevCommandTests testWithArguments]' failed (3.085 seconds).
Test Suite 'DevCommandTests' failed at 2024-06-05 22:14:32.147.
	 Executed 1 test, with 1 failure (1 unexpected) in 3.085 (3.085) seconds
Test Suite 'cartonPackageTests.xctest' failed at 2024-06-05 22:14:32.147.
	 Executed 1 test, with 1 failure (1 unexpected) in 3.085 (3.085) seconds
Test Suite 'Selected tests' failed at 2024-06-05 22:14:32.147.
	 Executed 1 test, with 1 failure (1 unexpected) in 3.085 (3.086) seconds
```
</details>