### PR TITLE
Skip hot-reloading if build fails

### DIFF
--- a/Plugins/CartonDevPlugin/CartonDevPluginCommand.swift
+++ b/Plugins/CartonDevPlugin/CartonDevPluginCommand.swift
@@ -49,7 +49,7 @@ struct CartonDevPluginCommand: CommandPlugin {
     // Build products
     var parameters = PackageManager.BuildParameters(
       configuration: options.release ? .release : .debug,
-      logging: options.verbose ? .verbose : .concise
+      logging: options.verbose ? .debug : .concise
     )
     #if compiler(>=5.11) || compiler(>=6)
     parameters.echoLogs = true
@@ -109,13 +109,16 @@ struct CartonDevPluginCommand: CommandPlugin {
     while let _ = try buildRequestFileHandle.read(upToCount: 1) {
       Diagnostics.remark("[Plugin] Received build request")
       let buildResult = try self.packageManager.build(buildSubset, parameters: parameters)
+      let responseMessage: Data
       if !buildResult.succeeded {
         Diagnostics.remark("[Plugin] **Build Failed**")
-        print(buildResult.logText)
+        print(buildResult.logText, terminator: "")
+        responseMessage = Data([0])
       } else {
         Diagnostics.remark("[Plugin] **Build Succeeded**")
+        responseMessage = Data([1])
       }
-      try buildResponseFileHandle.write(contentsOf: Data([1]))
+      try buildResponseFileHandle.write(contentsOf: responseMessage)
     }
 
     frontend.waitUntilExit()

--- a/Plugins/CartonDevPlugin/CartonDevPluginCommand.swift
+++ b/Plugins/CartonDevPlugin/CartonDevPluginCommand.swift
@@ -49,7 +49,7 @@ struct CartonDevPluginCommand: CommandPlugin {
     // Build products
     var parameters = PackageManager.BuildParameters(
       configuration: options.release ? .release : .debug,
-      logging: options.verbose ? .debug : .concise
+      logging: options.verbose ? .verbose : .concise
     )
     #if compiler(>=5.11) || compiler(>=6)
     parameters.echoLogs = true


### PR DESCRIPTION
# 課題

devコマンドはファイルの変更があるとリビルドをしますが、
この時、変更によってソースコードが壊れた場合、コンパイルに失敗することがあります。

しかし、プラグインはそれをフロントエンドに伝えていないため、
コンパイルに失敗したにも関わらず、
`Build completed successfully` と出力してからブラウザをリロードさせます。

ユーザがコードの編集中にこれが生じた場合、
successの表示と共にブラウザがリロードされたので、
ユーザは編集結果がブラウザにホットリロードされたと期待するでしょう。
しかし実際にはバイナリが更新されていないため、
動作確認がうまくいかず混乱するでしょう。

コンパイルエラーが出ていることは、
ターミナルの少し上を見なければわからず、
気づかない事があるでしょう。

# 提案

プラグインからフロントエンドにビルドが成功したかどうかを伝え、
失敗した場合にはそれを表示して、ブラウザのリロードはスキップします。

## 詳細

以下に変更前後の出力の変化を掲載します。
余計な空行も削除しています。

**変更前, リビルド成功時**

```
These paths have changed, rebuilding...
- /Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app
- /Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app

Build completed successfully
```

**変更前, リビルド失敗時**

```
These paths have changed, rebuilding...
- /Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app
- /Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app
Building for debugging...
[0/2] Write swift-version--1B43874C0F24DF5E.txt
[1/4] Write sources
[3/5] Compiling app main.swift
/Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app/main.swift:16:1: error: cannot find 'aaa' in scope
aaa
^~~


Build completed successfully
```

**変更前, リビルド成功時**

```
These paths have changed, rebuilding...
- /Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app
- /Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app
Build completed successfully
The app is currently hosted at http://127.0.0.1:8080/
```

**変更前, リビルド失敗時**

```
These paths have changed, rebuilding...
- /Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app
- /Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app
Building for debugging...
[0/2] Write swift-version--1B43874C0F24DF5E.txt
[1/4] Write sources
[3/5] Compiling app main.swift
/Users/omochi/github/swiftwasm/carton/Tests/Fixtures/SandboxApp/Sources/app/main.swift:16:1: error: cannot find 'aaa' in scope
aaa
^~~
Build failed
```

