### PR TITLE
Adaptive default toolchain version based on Swift version on builder

### DIFF
--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if compiler(>=5.10)
 public let defaultToolchainVersion = "wasm-5.10.0-RELEASE"
+#else
+public let defaultToolchainVersion = "wasm-5.9.2-RELEASE"
+#endif


### PR DESCRIPTION
現在、cartonの用意するツールチェーンのバージョンは固定でハードコードされています。
これは概ね現在の最新安定版を追従するように更新されています。

しかし、ユーザの開発環境はそれより古いものからまだアップグレードできていなかったり、
逆にリリース前の超最新版を使いたいこともあります。

そのような場合に、ソースコードの編集で使われる言語バージョンと、
cartonがwasmビルドで利用する言語バージョンが異なってしまいます。

対策方法として、`.swift-verison` ファイルを用意することで、
cartonが利用するバージョンを切り替えることができます。

しかしこれを使うまでもなく、
ユーザが期待するcartonに使って欲しいであろうバージョンは、
ユーザが `$ swift run carton bundle` するときに叩いている swift のバージョンでしょう。
ファイルで設定することなく、このように期待されるバージョンに切り替われば便利です。

このパッチでは、そのようにデフォルトを切り替えるように変更します。

cartonはswiftpmで依存pluginとして導入することが想定されているため、
そのSwiftのバージョンはcartonコードの中で `#if compiler` を判別することができます。
実装ではこれを使います。

事前に相談した会話:
https://discord.com/channels/291054398077927425/383442648012423179/1248990244888641648