### PR TITLE
Add Swift 6.0 CI for Linux

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -63,6 +63,9 @@ jobs:
       matrix:
         include:
           - swift:
+              dir: "swift-6.0-branch/ubuntu2204"
+              version: "swift-6.0-DEVELOPMENT-SNAPSHOT-2024-06-08-a"
+          - swift:
               dir: "swift-5.10-release/ubuntu2204"
               version: "swift-5.10-RELEASE"
           - swift:

--- a/Sources/CartonFrontend/Commands/CartonFrontendBundleCommand.swift
+++ b/Sources/CartonFrontend/Commands/CartonFrontendBundleCommand.swift
@@ -142,7 +142,8 @@ struct CartonFrontendBundleCommand: AsyncParsableCommand {
     async throws
   {
     var wasmOptArgs = [
-      "wasm-opt", "-Os", "--enable-bulk-memory", inputPath.pathString, "-o", outputPath.pathString,
+      "wasm-opt", "-Os", "--enable-bulk-memory", "--enable-sign-ext",
+      inputPath.pathString, "-o", outputPath.pathString,
     ]
     if debugInfo {
       wasmOptArgs.append("--debuginfo")

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -14,7 +14,7 @@
 
 #if compiler(>=6.0)
 public let defaultToolchainVersion = "wasm-6.0-SNAPSHOT-2024-06-08-a"
-#elseif compiler(>=5.10)
+#if compiler(>=5.10)
 public let defaultToolchainVersion = "wasm-5.10.0-RELEASE"
 #else
 public let defaultToolchainVersion = "wasm-5.9.2-RELEASE"

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -14,7 +14,7 @@
 
 #if compiler(>=6.0)
 public let defaultToolchainVersion = "wasm-6.0-SNAPSHOT-2024-06-08-a"
-#if compiler(>=5.10)
+#elseif compiler(>=5.10)
 public let defaultToolchainVersion = "wasm-5.10.0-RELEASE"
 #else
 public let defaultToolchainVersion = "wasm-5.9.2-RELEASE"


### PR DESCRIPTION
Linux の CI に Swift 6.0 を追加します。
#481 がマージ済みなので、Carton実行時も Swift 6.0 を使います。

---

- [x] LinuxのCIを追加する
- [x] macのCIを追加する at #483
- [x] デフォルトツールチェーン選択ロジックに 6.0 を追加する (see #481)