### PR TITLE
Add Swift 6.0 CI for building carton for macOS 

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,6 +16,12 @@ jobs:
         include:
           - os: macos-14
             xcode: "15.4"
+            swift: "6.0"
+            swift-install:
+              dir: "swift-6.0-branch/xcode"
+              version: "swift-6.0-DEVELOPMENT-SNAPSHOT-2024-06-07-a"
+          - os: macos-14
+            xcode: "15.4"
             swift: "5.10"
           - os: macos-13
             xcode: "15.2"
@@ -27,6 +33,13 @@ jobs:
 
       - name: Select Xcode version
         run: sudo xcode-select --switch /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
+      - name: Install Swift ${{ matrix.swift }}
+        if: ${{ matrix.swift-install != null }}
+        run: bash ci/mac/install-swift.bash
+        env:
+          SWIFT_DIR: ${{ matrix.swift-install.dir }}
+          SWIFT_VERSION: ${{ matrix.swift-install.version }}
 
       - name: Check Swift version
         run: swift --version
@@ -47,15 +60,14 @@ jobs:
     timeout-minutes: 40
     runs-on: ubuntu-22.04
     strategy:
-      matrix:
-        include:
-          - swift:
-              dir: "swift-5.10-release/ubuntu2204"
-              version: "swift-5.10-RELEASE"
-          - swift:
-              dir: "swift-5.9.2-release/ubuntu2204"
-              version: "swift-5.9.2-RELEASE"
-
+       matrix:
+         include:
+           - swift:
+               dir: "swift-5.10-release/ubuntu2204"
+               version: "swift-5.10-RELEASE"
+           - swift:
+               dir: "swift-5.9.2-release/ubuntu2204"
+               version: "swift-5.9.2-RELEASE"
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -60,14 +60,14 @@ jobs:
     timeout-minutes: 40
     runs-on: ubuntu-22.04
     strategy:
-       matrix:
-         include:
-           - swift:
-               dir: "swift-5.10-release/ubuntu2204"
-               version: "swift-5.10-RELEASE"
-           - swift:
-               dir: "swift-5.9.2-release/ubuntu2204"
-               version: "swift-5.9.2-RELEASE"
+      matrix:
+        include:
+          - swift:
+              dir: "swift-5.10-release/ubuntu2204"
+              version: "swift-5.10-RELEASE"
+          - swift:
+              dir: "swift-5.9.2-release/ubuntu2204"
+              version: "swift-5.9.2-RELEASE"
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/ci/mac/install-swift.bash
+++ b/ci/mac/install-swift.bash
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ue
+cd "$(dirname "$0")/../.."
+
+mkdir -p install
+cd install
+
+set -x
+pwd
+curl -fLO https://download.swift.org/${SWIFT_DIR}/${SWIFT_VERSION}/${SWIFT_VERSION}-osx.pkg
+installer -target CurrentUserHomeDirectory -pkg ${SWIFT_VERSION}-osx.pkg
+
+toolchain=~/Library/Developer/Toolchains/${SWIFT_VERSION}.xctoolchain
+
+set +x
+swift_id=$(plutil -extract CFBundleIdentifier raw ${toolchain}/Info.plist)
+
+set -x
+echo "TOOLCHAINS=${swift_id}" >> $GITHUB_ENV
+
+# https://github.com/apple/swift/issues/73327#issuecomment-2120481479
+find ${toolchain}/usr/bin -type f | xargs -n 1 -I {} \
+  sudo codesign --force --preserve-metadata=identifier,entitlements --sign - {}
+
+echo "DYLD_LIBRARY_PATH=${toolchain}/usr/lib/swift/macosx" >> $GITHUB_ENV


### PR DESCRIPTION
macのCIにSwift6.0を追加します。
そのままだと動かないので↓のハックをCIでインストールするときに適応します。
https://github.com/apple/swift/issues/73327#issuecomment-2120481479

6.0でビルドされたcartonがインストールするSwiftは5.10のままです。
これは別パッチにして後で出します。 #484 で作業しています。

そのため、この変更では、
cartonコードベースがSwift6.0でビルドできるかどうかを検証するだけで、
自動テストで動作検証する時の挙動は5.10のままです。

PRを提出するときに先頭コメントを書き換えました。
後続コメントは作業中のメモなので無視してください。