### PR TITLE
Newline after command-line logging output

### DIFF
--- a/Sources/CartonHelpers/Process+run.swift
+++ b/Sources/CartonHelpers/Process+run.swift
@@ -83,7 +83,7 @@ extension Process {
             outputRedirection: .stream(stdout: stdout, stderr: stderr),
             startNewProcessGroup: true,
             loggingHandler: {
-              terminal.write($0)
+              terminal.write($0 + "\n")
             }
           )
 


### PR DESCRIPTION
Otherwise, the stdout/stderr output begins on the same line as the command-line logging output, which can be confusing.