### PR TITLE
Remove the workaround for the linker issue in Swift 6.0

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,7 @@ jobs:
             swift: "6.0"
             swift-install:
               dir: "swift-6.0-branch/xcode"
-              version: "swift-6.0-DEVELOPMENT-SNAPSHOT-2024-06-07-a"
+              version: "swift-6.0-DEVELOPMENT-SNAPSHOT-2024-06-19-a"
           - os: macos-14
             xcode: "15.4"
             swift: "5.10"

--- a/Sources/CartonCore/Environment.swift
+++ b/Sources/CartonCore/Environment.swift
@@ -63,12 +63,6 @@ public enum Environment: String, CaseIterable {
     // for future dynamic linking support.
     parameters.otherSwiftcFlags += ["-static-stdlib"]
 
-    #if compiler(>=6.0) && compiler(<6.1)
-    // A workaround for the linker issue.
-    // https://github.com/swiftwasm/swift/issues/5580
-    parameters.otherLinkerFlags += ["-lswift_RegexParser"]
-    #endif
-
     switch self {
     case .command: break
     case .node, .browser:

--- a/Sources/CartonHelpers/DefaultToolchain.swift
+++ b/Sources/CartonHelpers/DefaultToolchain.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #if compiler(>=6.0)
-public let defaultToolchainVersion = "wasm-6.0-SNAPSHOT-2024-06-08-a"
+public let defaultToolchainVersion = "wasm-6.0-SNAPSHOT-2024-06-19-a"
 #elseif compiler(>=5.10)
 public let defaultToolchainVersion = "wasm-5.10.0-RELEASE"
 #else


### PR DESCRIPTION
It's fixed in the main branch and cherry-picked to the 6.0 branch.

See https://github.com/apple/swift/pull/74277