### PR TITLE
Put `--dir` wasmtime option before the test file path

### DIFF
--- a/Sources/CartonFrontend/Commands/TestRunners/CommandTestRunner.swift
+++ b/Sources/CartonFrontend/Commands/TestRunners/CommandTestRunner.swift
@@ -33,20 +33,23 @@ struct CommandTestRunner: TestRunner {
   func run() async throws {
     let program = try ProcessInfo.processInfo.environment["CARTON_TEST_RUNNER"] ?? defaultWASIRuntime()
     terminal.write("\nRunning the test bundle with \"\(program)\":\n", inColor: .yellow)
-    var arguments = [program, testFilePath.pathString]
+
+    var arguments = [program]
+    var xctestArgs: [String] = []
     if listTestCases {
-      arguments.append(contentsOf: ["--", "-l"])
+      xctestArgs.append(contentsOf: ["--", "-l"])
     } else {
-      let programName = (program as NSString).lastPathComponent
+      let programName = URL(fileURLWithPath: program).lastPathComponent
       if programName == "wasmtime" {
         arguments += ["--dir", "."]
       }
 
       if !testCases.isEmpty {
-        arguments.append("--")
-        arguments.append(contentsOf: testCases)
+        xctestArgs.append("--")
+        xctestArgs.append(contentsOf: testCases)
       }
     }
+    arguments += [testFilePath.pathString] + xctestArgs
     try await Process.run(arguments, parser: TestsParser(), terminal)
   }
 


### PR DESCRIPTION
It was broken in the latest wasmtime release 22 https://github.com/swiftwasm/carton/actions/runs/9607328437/job/26498300308#step:8:2365