### PR TITLE
Remove swift-log dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,6 @@ let package = Package(
   name: "carton",
   platforms: [.macOS(.v13)],
   products: [
-    .library(name: "SwiftToolchain", targets: ["SwiftToolchain"]),
-    .library(name: "CartonHelpers", targets: ["CartonHelpers"]),
-    .library(name: "CartonDriver", targets: ["CartonDriver"]),
-    .library(name: "CartonKit", targets: ["CartonKit"]),
-    .library(name: "CartonFrontend", targets: ["CartonFrontend"]),
     .executable(name: "carton", targets: ["carton"]),
     .executable(name: "carton-release", targets: ["carton-release"]),
     .plugin(name: "CartonBundlePlugin", targets: ["CartonBundlePlugin"]),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,6 @@ let package = Package(
     .executable(name: "carton-plugin-helper", targets: ["carton-plugin-helper"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
       .upToNextMinor(from: "1.3.0")
@@ -101,7 +100,6 @@ let package = Package(
     .target(
       name: "CartonFrontend",
       dependencies: [
-        .product(name: "Logging", package: "swift-log"),
         "CartonKit",
       ]
     ),

--- a/Sources/CartonKit/Server/Server.swift
+++ b/Sources/CartonKit/Server/Server.swift
@@ -15,7 +15,6 @@
 import CartonCore
 import CartonHelpers
 import Foundation
-import Logging
 import NIO
 import NIOHTTP1
 import NIOWebSocket
@@ -65,6 +64,18 @@ extension Event: Decodable {
 
 public struct BuilderProtocolSimpleBuildFailedError: Error {
   public init() {}
+}
+
+/// A simple logger that logs messages to the console.
+struct Logger {
+  let label: String
+
+  func info(_ message: String) {
+    Swift.print("INFO [\(label)] \(message)")
+  }
+  func error(_ message: String) {
+    Swift.print("ERROR [\(label)] \(message)")
+  }
 }
 
 /// A protocol for a builder that can be used to build the app.

--- a/Sources/CartonKit/Server/ServerHTTPHandler.swift
+++ b/Sources/CartonKit/Server/ServerHTTPHandler.swift
@@ -14,7 +14,6 @@
 
 import CartonHelpers
 import Foundation
-import Logging
 import NIO
 import NIOHTTP1
 

--- a/Tests/Fixtures/TestApp/Package.resolved
+++ b/Tests/Fixtures/TestApp/Package.resolved
@@ -38,15 +38,6 @@
         }
       },
       {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-          "version": "1.5.4"
-        }
-      },
-      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {


### PR DESCRIPTION
Carton won't be a library, so we don't need a centralized logging system. Removing a dependency speeds up the build